### PR TITLE
publish golang.Go extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -250,6 +250,11 @@
       "checkout": "v1.1.2"
     },
     {
+      "id": "golang.Go",
+      "repository": "https://github.com/golang/vscode-go",
+      "checkout": "latest"
+    },
+    {
       "id": "GrapeCity.gc-excelviewer",
       "version": "2.1.35",
       "repository": "https://github.com/jjuback/gc-excelviewer",


### PR DESCRIPTION
ms-vscode.Go has been migrated to golang.Go.
This should replace https://open-vsx.org/extension/ms-vscode/Go

Update https://github.com/golang/vscode-go/issues/222