### PR TITLE
Prepublish github-vscode-theme

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -282,7 +282,8 @@
       "id": "GitHub.github-vscode-theme",
       "repository": "https://github.com/primer/github-vscode-theme",
       "version": "1.1.2",
-      "checkout": "v1.1.2"
+      "checkout": "v1.1.2",
+      "prepublish": "npm run build"
     },
     {
       "id": "golang.Go",


### PR DESCRIPTION
👋  We got a report that the `github-vscode-theme` doesn't work without running `npm run build` first, see https://github.com/primer/github-vscode-theme/issues/66.

This PR adds the `prepublish` option and hopefully fixes the issue.