### PR TITLE
[markdown lint] fix compilation of extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -170,7 +170,8 @@
       "id": "DavidAnson.vscode-markdownlint",
       "repository": "https://github.com/DavidAnson/vscode-markdownlint",
       "version": "0.36.1",
-      "checkout": "v0.36.1"
+      "checkout": "v0.36.1",
+      "prepublish": "npm run compile"
     },
     {
       "id": "denoland.vscode-deno",


### PR DESCRIPTION
I hope this fixes #77

The default way of building this extension does not seem to result
in a working extension. Not sure what's missing, but it's much
smaller vs when fully built.

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>