### PR TITLE
Auto-publish VSCODE POWER MODE!!!

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -361,6 +361,10 @@
       "version": "1.4.11"
     },
     {
+      "id": "hoovercj.vscode-power-mode",
+      "repository": "https://github.com/hoovercj/vscode-power-mode"
+    },
+    {
       "id": "humao.rest-client",
       "repository": "https://github.com/Huachao/vscode-restclient",
       "version": "0.24.1",


### PR DESCRIPTION
It would be awesome to have https://github.com/hoovercj/vscode-power-mode available on https://open-vsx.org, so that non-Microsoft tools like VSCodium, Theia and Gitpod can also benefit from VSCODE POWER MODE!!!

We could auto-publish it here, but it would probably be better if the original developers publish it to OpenVSX directly.

@hoovercj would you be interested in publishing VSCODE POWER MODE!!! to https://open-vsx.org ?

It's basically just a matter of running `npx ovsx publish` (no dependencies needed, just a `OVSX_PAT` token that you can get [here](https://open-vsx.org/user-settings/tokens)).