### PR TITLE
Allow downloading already packaged extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Here are all the supported values, including optional ones:
       "id": "rebornix.ruby",
       // Repository URL to clone and publish from
       "repository": "https://github.com/rubyide/vscode-ruby",
-      // (RECOMMENDED) The version that should be published on Open VSX (defaults to the package.json version)
+      // (RECOMMENDED) The version that should be published; the script compares this version with the latest published version
       "version": "0.27.0",
       // (RECOMMENDED) The Git branch, tag, or commit to check out before publishing (defaults to the repository's default branch)
       "checkout": "v0.27.0",
@@ -44,6 +44,19 @@ Here are all the supported values, including optional ones:
       "location": "packages/vscode-ruby-client",
       // (OPTIONAL) Extra commands to run just before publishing to Open VSX (i.e. after "yarn/npm install", but before "vscode:prepublish")
       "prepublish": "npm run build"
+    },
+```
+
+In cases where it is not feasible to build the extension from source, a download URL can be given instead:
+
+```js
+    {
+      // Unique Open VSX extension ID in the form "<namespace>.<name>"
+      "id": "rebornix.ruby",
+      // (RECOMMENDED) The version that should be published; the script compares this version with the latest published version
+      "version": "0.25.0",
+      // A full URL from which to download the extension package
+      "download": "https://github.com/rubyide/vscode-ruby/releases/download/v0.25.0/ruby-0.25.0.vsix",
     },
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ In cases where it is not feasible to build the extension from source, a download
     {
       // Unique Open VSX extension ID in the form "<namespace>.<name>"
       "id": "rebornix.ruby",
-      // (RECOMMENDED) The version that should be published; the script compares this version with the latest published version
-      "version": "0.25.0",
       // A full URL from which to download the extension package
       "download": "https://github.com/rubyide/vscode-ruby/releases/download/v0.25.0/ruby-0.25.0.vsix",
+      // (RECOMMENDED) The version that should be published; the script compares this version with the latest published version
+      "version": "0.25.0"
     },
 ```
 

--- a/extensions.json
+++ b/extensions.json
@@ -585,7 +585,6 @@
     },
     {
       "id": "ms-python.python",
-      "version": "2020.7.1",
       "download": "https://github.com/Microsoft/vscode-python/releases/download/2020.7.96456/ms-python-release.vsix"
     },
     {

--- a/extensions.json
+++ b/extensions.json
@@ -585,10 +585,8 @@
     },
     {
       "id": "ms-python.python",
-      "repository": "https://github.com/Microsoft/vscode-python",
       "version": "2020.7.1",
-      "checkout": "2020.7.96456",
-      "prepublish": "python -m pip install -U pip && python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade -r requirements.txt && python -m pip install wheel && python -m pip --disable-pip-version-check install -r build/debugger-install-requirements.txt && python ./pythonFiles/install_debugpy.py && npm run clean && npm run package"
+      "download": "https://github.com/Microsoft/vscode-python/releases/download/2020.7.96456/ms-python-release.vsix"
     },
     {
       "id": "ms-vscode.atom-keybindings",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
     "publish": "node publish-extensions"
   },
   "dependencies": {
+    "download": "^8.0.0",
     "minimist": "^1.2.5",
-    "ovsx": "0.1.0-next.9321255",
+    "ovsx": "0.1.0-next.bcce4bc",
     "semver": "^7.1.3"
   },
   "devDependencies": {}

--- a/publish-extensions.js
+++ b/publish-extensions.js
@@ -14,11 +14,24 @@ const ovsx = require('ovsx');
 const path = require('path');
 const util = require('util');
 const semver = require('semver');
+const download = require('download');
 const exec = require('./lib/exec');
 const readFile = util.promisify(fs.readFile);
 
 (async () => {
-  /** @type {{ extensions: { id: string, repository: string, version?: string, checkout?: string, location?: string, prepublish?: string }[] }} */
+  /**
+   * @type {{
+   *    extensions: {
+   *        id: string,
+   *        repository: string,
+   *        version?: string,
+   *        checkout?: string,
+   *        location?: string,
+   *        prepublish?: string,
+   *        download?: string
+   *    }[]
+   * }}
+   */
   const { extensions } = JSON.parse(await readFile('./extensions.json', 'utf-8'));
   const registry = new ovsx.Registry();
 
@@ -28,10 +41,7 @@ const readFile = util.promisify(fs.readFile);
   for (const extension of extensions) {
     console.log(`\nProcessing extension: ${JSON.stringify(extension, null, 2)}`);
     try {
-      const { id, repository } = extension;
-      if (!new URL(repository)) {
-        throw new Error(`Invalid repository URL: ${repository}`);
-      }
+      const { id } = extension;
 
       console.log(`Checking Open VSX version of ${id}`);
       let ovsxVersion;
@@ -57,19 +67,6 @@ const readFile = util.promisify(fs.readFile);
 
       console.log(`Attempting to publish ${id} to Open VSX`);
 
-      // Clone and set up the repository.
-      await exec(`git clone --recurse-submodules ${repository} /tmp/repository`);
-      if (extension.checkout) {
-        await exec(`git checkout ${extension.checkout}`, { cwd: '/tmp/repository' });
-      }
-      let yarn = await new Promise(resolve => {
-        fs.access(path.join('/tmp/repository', 'yarn.lock'), error => resolve(!error));
-      });
-      await exec(`${yarn ? 'yarn' : 'npm'} install`, { cwd: '/tmp/repository' });
-      if (extension.prepublish) {
-        await exec(extension.prepublish, { cwd: '/tmp/repository' })
-      }
-
       // Create a public Open VSX namespace if needed.
       try {
         await ovsx.createNamespace({ name: namespace });
@@ -78,19 +75,59 @@ const readFile = util.promisify(fs.readFile);
         console.log(error);
       }
 
-      // Publish the extension.
-      const options = { packagePath: path.join('/tmp/repository', extension.location || '.') };
-      if (yarn) {
-        options.yarn = true;
+      if (extension.download) {
+        if (extension.repository) {
+          console.warn('[WARN] Ignoring `repository` property because `download` was given.')
+        }
+        if (extension.checkout) {
+          console.warn('[WARN] Ignoring `checkout` property because `download` was given.')
+        }
+        if (extension.prepublish) {
+          console.warn('[WARN] Ignoring `prepublish` property because `download` was given.')
+        }
+        if (extension.location) {
+          console.warn('[WARN] Ignoring `location` property because `download` was given.')
+        }
+
+        // Download the extension package from a GitHub release
+        console.log(`Downloading ${extension.download}`);
+        await download(extension.download, '/tmp/download', { filename: 'extension.vsix' });
+
+        // Publish the extension.
+        /** @type {import('ovsx').PublishOptions} */
+        const options = { extensionFile: '/tmp/download/extension.vsix' };
+        await ovsx.publish(options);
+        console.log(`[OK] Successfully published ${id} to Open VSX!`)
+
+      } else {
+        // Clone and set up the repository.
+        await exec(`git clone --recurse-submodules ${extension.repository} /tmp/repository`);
+        if (extension.checkout) {
+            await exec(`git checkout ${extension.checkout}`, { cwd: '/tmp/repository' });
+        }
+        let yarn = await new Promise(resolve => {
+            fs.access(path.join('/tmp/repository', 'yarn.lock'), error => resolve(!error));
+        });
+        await exec(`${yarn ? 'yarn' : 'npm'} install`, { cwd: '/tmp/repository' });
+        if (extension.prepublish) {
+            await exec(extension.prepublish, { cwd: '/tmp/repository' })
+        }
+
+        // Publish the extension.
+        /** @type {import('ovsx').PublishOptions} */
+        const options = { packagePath: path.join('/tmp/repository', extension.location || '.') };
+        if (yarn) {
+            options.yarn = true;
+        }
+        await ovsx.publish(options);
+        console.log(`[OK] Successfully published ${id} to Open VSX!`)
       }
-      await ovsx.publish(options);
-      console.log(`[OK] Successfully published ${id} to Open VSX!`)
     } catch (error) {
       console.error(`[FAIL] Could not process extension: ${JSON.stringify(extension, null, 2)}`);
       console.error(error);
       process.exitCode = -1;
     } finally {
-      await exec('rm -rf /tmp/repository');
+      await exec('rm -rf /tmp/repository /tmp/download');
     }
   }
 })();

--- a/publish-extensions.js
+++ b/publish-extensions.js
@@ -89,7 +89,7 @@ const readFile = util.promisify(fs.readFile);
           console.warn('[WARN] Ignoring `location` property because `download` was given.')
         }
 
-        // Download the extension package from a GitHub release
+        // Download the extension package, e.g. from a GitHub release
         console.log(`Downloading ${extension.download}`);
         await download(extension.download, '/tmp/download', { filename: 'extension.vsix' });
 
@@ -97,7 +97,6 @@ const readFile = util.promisify(fs.readFile);
         /** @type {import('ovsx').PublishOptions} */
         const options = { extensionFile: '/tmp/download/extension.vsix' };
         await ovsx.publish(options);
-        console.log(`[OK] Successfully published ${id} to Open VSX!`)
 
       } else {
         // Clone and set up the repository.
@@ -120,8 +119,9 @@ const readFile = util.promisify(fs.readFile);
             options.yarn = true;
         }
         await ovsx.publish(options);
-        console.log(`[OK] Successfully published ${id} to Open VSX!`)
+
       }
+      console.log(`[OK] Successfully published ${id} to Open VSX!`)
     } catch (error) {
       console.error(`[FAIL] Could not process extension: ${JSON.stringify(extension, null, 2)}`);
       console.error(error);


### PR DESCRIPTION
This change adds a `download` option that can be used to download and publish an already packaged extension. This can be useful for cases where it is not feasible to build an extension from source.