### PR TITLE
[justusadam.language-haskell] Add 'make all' for the justusadam.language-haskell extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -461,7 +461,7 @@
       "repository": "https://github.com/JustusAdam/language-haskell",
       "version": "3.3.0",
       "checkout": "v3.3.0",
-      "prepublish": "npm i --save-dev @types/node@10"
+      "prepublish": "npm i --save-dev @types/node@10 && make all"
     },
     {
       "id": "karunamurti.haml",


### PR DESCRIPTION
__Issue:__ The [language-haskell](https://open-vsx.org/extension/justusadam/language-haskell) plugin is missing syntax files. These are intended to be generated during the build, via `make all`, but this wasn't included in the publish script. This means that the extension is broken - at least for syntax highlighting.

We noticed this in https://github.com/onivim/oni2/issues/2307 using the language-haskell extension published to open-vsx.

__Fix:__ Add `make all` to the prepublish script for `language-haskell`.

Related:
- https://github.com/JustusAdam/language-haskell/issues/171 - tracking publishing by author