### PR TITLE
Add godot-vscode-plugin

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -358,6 +358,11 @@
       "repository": "https://gitlab.com/fr43nk/seito-openfile"
     },
     {
+      "id": "geequlim.godot-tools",
+      "download": "https://github.com/godotengine/godot-vscode-plugin/releases/download/1.0.1/godot-tools-1.0.1.vsix",
+      "version": "1.0.1"
+    },
+    {
       "id": "giscafer.leek-fund",
       "repository": "https://github.com/giscafer/leek-fund"
     },


### PR DESCRIPTION
Hi, 

This PR adds the godot-vscode-plugin: https://github.com/godotengine/godot-vscode-plugin which is [MIT licensed](https://github.com/godotengine/godot-vscode-plugin/blob/master/LICENSE), and uses the download VSIX package here: https://github.com/godotengine/godot-vscode-plugin/releases/download/1.0.1/godot-tools-1.0.1.vsix