### PR TITLE
foam master fails prepublish: use fixed version

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -329,7 +329,9 @@
     {
       "id": "foam.foam-vscode",
       "repository": "https://github.com/foambubble/foam",
-      "location": "packages/foam-vscode"
+      "location": "packages/foam-vscode",
+      "version": "0.3.1",
+      "checkout": "v0.3.1"
     },
     {
       "id": "formulahendry.auto-close-tag",


### PR DESCRIPTION
Foam is currently out-of-date: v0.1.7, latest is v0.3.1.

Explicitly use a version number to try to fix build failure.

The build failure on master is:
```
 $ tsc -p ./
##[error]src/extension.ts(22,8): error TS6305: Output file '/tmp/repository/packages/foam-core/dist/index.d.ts' has not been built from source file '/tmp/repository/packages/foam-core/src/index.ts'.
##[error]src/features/janitor.ts(16,8): error TS6305: Output file '/tmp/repository/packages/foam-core/dist/index.d.ts' has not been built from source file '/tmp/repository/packages/foam-core/src/index.ts'.
##[error]src/features/wikilink-reference-generation.ts(24,8): error TS6305: Output file '/tmp/repository/packages/foam-core/dist/index.d.ts' has not been built from source file '/tmp/repository/packages/foam-core/src/index.ts'.
##[error]src/types.d.ts(2,22): error TS6305: Output file '/tmp/repository/packages/foam-core/dist/index.d.ts' has not been built from source file '/tmp/repository/packages/foam-core/src/index.ts'.
error Command failed with exit code 2.
```