### PR TITLE
Add Argdown extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -164,6 +164,13 @@
       "version": "2.2.1"
     },
     {
+      "id": "christianvoigt.argdown-vscode",
+      "repository": "https://github.com/christianvoigt/argdown",
+      "version": "1.5.0",
+      "checkout": "be86c880e39da3d963b2f63855f30616a1704703",
+      "location": "packages/argdown-vscode"
+    },
+    {
       "id": "CoenraadS.bracket-pair-colorizer",
       "repository": "https://github.com/CoenraadS/BracketPair",
       "version": "1.0.61"


### PR DESCRIPTION
See https://argdown.org/ for details.

I'm not sure that hack with `rm -f .yarnrc` in "checkout" will actually work. Is there any way to test this before merging?