### PR TITLE
Fix vetur extension: compiled javascript was not included in bundle

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -675,9 +675,8 @@
     },
     {
       "id": "octref.vetur",
-      "repository": "https://github.com/vuejs/vetur",
-      "version": "0.26.1",
-      "checkout": "v0.26.1"
+      "download": "https://github.com/vuejs/vetur/releases/download/v0.27.0/vetur-0.27.0.vsix",
+      "version": "0.27.0"
     },
     {
       "id": "oderwat.indent-rainbow",


### PR DESCRIPTION
The [`vetur`](https://github.com/vuejs/vetur) extension has build steps that aren't included in the current `extensions.json`, so it was missing some build output necessary for running.

Came across as this error during runtime:
![image](https://user-images.githubusercontent.com/13532591/92153484-3456a080-edd9-11ea-99e2-900d198c4778.png)

This uses the download-vsix strategy instead, which includes the build output needed for activation