### PR TITLE
Fix Argdown

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -172,7 +172,8 @@
       "repository": "https://github.com/christianvoigt/argdown",
       "version": "1.5.0",
       "checkout": "be86c880e39da3d963b2f63855f30616a1704703",
-      "location": "packages/argdown-vscode"
+      "location": "packages/argdown-vscode",
+      "prepublish": "cd packages/argdown-vscode && yarn install"
     },
     {
       "id": "CoenraadS.bracket-pair-colorizer",


### PR DESCRIPTION
Currently it fails with

```
sh: 1: rimraf: not found
```

(https://github.com/open-vsx/publish-extensions/runs/1074685213)