### PR TITLE
Fix the name of the extension ID.

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -798,9 +798,8 @@
     },
     {
       "id": "shan.code-settings-sync",
-      "repository": "https://github.com/shanalikhan/code-settings-sync",
-      "version": "3.4.3",
-      "checkout": "v3.4.3"
+      "download": "https://github.com/shanalikhan/code-settings-sync/releases/download/v3.4.3/code-settings-sync-3.4.3.vsix",
+      "version": "3.4.3"
     },
     {
       "id": "shinichi-takii.sql-bigquery",

--- a/extensions.json
+++ b/extensions.json
@@ -797,7 +797,7 @@
       "prepublish": "sed -ri \"s_git\\+https://_https://_g\" package.json"
     },
     {
-      "id": "Shan.code-settings-sync",
+      "id": "shan.code-settings-sync",
       "repository": "https://github.com/shanalikhan/code-settings-sync",
       "version": "3.4.3",
       "checkout": "v3.4.3"


### PR DESCRIPTION
I was trying to install the [Settings Sync](https://marketplace.visualstudio.com/itemdetails?itemName=Shan.code-settings-sync) extension but it still not available in the [Open VSX Registry](https://open-vsx.org/) even though that it already exist in `extensions.json` file.

So, I took a look to the `extensions.json` file and I found that the extension ID name was capitalized so it may fix the issue.