### PR TITLE
Removing CoenraadS.bracket-pair-colorizer-2 because publishing was taken over by @JorgeVV

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -185,11 +185,6 @@
       "version": "1.0.61"
     },
     {
-      "id": "CoenraadS.bracket-pair-colorizer-2",
-      "repository": "https://github.com/CoenraadS/Bracket-Pair-Colorizer-2",
-      "version": "0.1.4"
-    },
-    {
       "id": "connorshea.vscode-ruby-test-adapter",
       "repository": "https://github.com/connorshea/vscode-ruby-test-adapter",
       "version": "0.7.1",


### PR DESCRIPTION
See: https://open-vsx.org/extension/CoenraadS/bracket-pair-colorizer-2

Many thanks for taking care of this @JorgeVV! 🙏 