### PR TITLE
Add deibit.devdocs

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -244,6 +244,11 @@
       "version": "2.1.8"
     },
     {
+      "id": "deibit.devdocs",
+      "repository": "https://github.com/deibit/vscode-devdocs",
+      "version": "0.2.0"
+    },
+    {
       "id": "denoland.vscode-deno",
       "repository": "https://github.com/denoland/vscode_deno"
     },

--- a/extensions.json
+++ b/extensions.json
@@ -245,8 +245,7 @@
     },
     {
       "id": "deibit.devdocs",
-      "repository": "https://github.com/deibit/vscode-devdocs",
-      "version": "0.2.0"
+      "repository": "https://github.com/deibit/vscode-devdocs"
     },
     {
       "id": "denoland.vscode-deno",


### PR DESCRIPTION
[devdocs](https://marketplace.visualstudio.com/items?itemName=deibit.devdocs) is an MIT-licensed extension that adds a command to quickly search for selected text in [DevDocs](https://devdocs.io/), automatically inferring the language/framework search context from the file type.

While the repo doesn't have any git tags and its [`package.json`](https://github.com/deibit/vscode-devdocs/blob/master/package.json) doesn't include any packaging or publishing scripts, I tried cloning it myself and running

```zsh
vsce package
code --install-extension devdocs-0.2.0.vsix
```

...and it installed a perfectly functioning extension in my VSCodium installation, so we should have everything we need. 👍🏼