### PR TITLE
Auto-publish rafaelmaiolla.diff

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -931,6 +931,12 @@
       "version": "0.28.0"
     },
     {
+      "id": "rafaelmaiolla.diff",
+      "repository": "https://github.com/rafaelmaiolla/diff-vscode/",
+      "version": "0.0.1",
+      "checkout": "f9fef4e2e6867f9850809f9a7f54e700e17fc7d5"
+    },
+    {
       "id": "rebornix.ruby",
       "repository": "https://github.com/rubyide/vscode-ruby",
       "version": "0.27.0",


### PR DESCRIPTION
[That extension](https://marketplace.visualstudio.com/items?itemName=rafaelmaiolla.diff) is a simple extension providing syntax highlighting for `.patch` and `.diff` files. It is MIT licenced https://github.com/rafaelmaiolla/diff-vscode/blob/f9fef4e2e6867f9850809f9a7f54e700e17fc7d5/LICENSE.txt.

I suggested author to publish themselves in https://github.com/rafaelmaiolla/diff-vscode/issues/4 but got no reply, so after a few weeks I'm making this PR so that it gets published automatically on open-vsx.

