### PR TITLE
Added cmake-tools and cpp-tools to extensions

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -659,6 +659,10 @@
       "repository": "https://github.com/BeastCode/VSCode-Angular-TypeScript-Snippets"
     },
     {
+      "id": "microsoft.vscode-cmake-tools",
+      "repository": "https://github.com/microsoft/vscode-cmake-tools"
+    },
+    {
       "id": "mikestead.dotenv",
       "repository": "https://github.com/mikestead/vscode-dotenv",
       "version": "1.0.1"

--- a/extensions.json
+++ b/extensions.json
@@ -663,6 +663,31 @@
       "repository": "https://github.com/microsoft/vscode-cmake-tools"
     },
     {
+      "id": "microsoft.vscode-cpptools-linux",
+      "download": "https://github.com/microsoft/vscode-cpptools/releases/download/1.0.1/cpptools-linux.vsix",
+      "version": "1.0.1"
+    },
+    {
+      "id": "microsoft.vscode-cpptools-linuxARM32",
+      "download": "https://github.com/microsoft/vscode-cpptools/releases/download/1.0.1/cpptools-linux-armhf.vsix",
+      "version": "1.0.1"
+    },
+    {
+      "id": "microsoft.vscode-cpptools-linuxARM64",
+      "download": "https://github.com/microsoft/vscode-cpptools/releases/download/1.0.1/cpptools-linux-aarch64.vsix",
+      "version": "1.0.1"
+    },
+    {
+      "id": "microsoft.vscode-cpptools-macOS",
+      "download": "https://github.com/microsoft/vscode-cpptools/releases/download/1.0.1/cpptools-osx.vsix",
+      "version": "1.0.1"
+    },
+    {
+      "id": "microsoft.vscode-cpptools-windows",
+      "download": "https://github.com/microsoft/vscode-cpptools/releases/download/1.0.1/cpptools-win32.vsix",
+      "version": "1.0.1"
+    },
+    {
       "id": "mikestead.dotenv",
       "repository": "https://github.com/mikestead/vscode-dotenv",
       "version": "1.0.1"

--- a/extensions.json
+++ b/extensions.json
@@ -663,31 +663,6 @@
       "repository": "https://github.com/microsoft/vscode-cmake-tools"
     },
     {
-      "id": "microsoft.vscode-cpptools-linux",
-      "download": "https://github.com/microsoft/vscode-cpptools/releases/download/1.0.1/cpptools-linux.vsix",
-      "version": "1.0.1"
-    },
-    {
-      "id": "microsoft.vscode-cpptools-linuxARM32",
-      "download": "https://github.com/microsoft/vscode-cpptools/releases/download/1.0.1/cpptools-linux-armhf.vsix",
-      "version": "1.0.1"
-    },
-    {
-      "id": "microsoft.vscode-cpptools-linuxARM64",
-      "download": "https://github.com/microsoft/vscode-cpptools/releases/download/1.0.1/cpptools-linux-aarch64.vsix",
-      "version": "1.0.1"
-    },
-    {
-      "id": "microsoft.vscode-cpptools-macOS",
-      "download": "https://github.com/microsoft/vscode-cpptools/releases/download/1.0.1/cpptools-osx.vsix",
-      "version": "1.0.1"
-    },
-    {
-      "id": "microsoft.vscode-cpptools-windows",
-      "download": "https://github.com/microsoft/vscode-cpptools/releases/download/1.0.1/cpptools-win32.vsix",
-      "version": "1.0.1"
-    },
-    {
       "id": "mikestead.dotenv",
       "repository": "https://github.com/mikestead/vscode-dotenv",
       "version": "1.0.1"

--- a/extensions.json
+++ b/extensions.json
@@ -660,7 +660,8 @@
     },
     {
       "id": "microsoft.vscode-cmake-tools",
-      "repository": "https://github.com/microsoft/vscode-cmake-tools"
+      "version": "1.4.2",
+      "download": "https://github.com/microsoft/vscode-cmake-tools/releases/download/1.4.2/cmake-tools.vsix"
     },
     {
       "id": "mikestead.dotenv",


### PR DESCRIPTION
**cmake-tools** : Easily configure and build cmake based projects.

**cpp-tools**: intellisense and debugger frontend. Is platform specific, hence the multiple versions. Integrates well with cmake-tools. 