### PR TITLE
Add richie5um2.vscode-sort-json

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -958,6 +958,10 @@
       "location": "packages/vscode-ruby-client"
     },
     {
+      "id": "richie5um2.vscode-sort-json",
+      "repository": "https://github.com/richie5um/vscode-sort-json"
+    },
+    {
       "id": "ritwickdey.LiveServer",
       "repository": "https://github.com/ritwickdey/vscode-live-server",
       "version": "5.6.1",


### PR DESCRIPTION
[Sort JSON objects](https://marketplace.visualstudio.com/items?itemName=richie5um2.vscode-sort-json) is an MIT-licensed extension that adds some quick commands to sort a selected JSON object in various ways. The repo doesn't have any git tags, and its [`package.json`](https://github.com/richie5um/vscode-sort-json/blob/683320a27a266d56d8fa8f80d2c1b7cc9cfe6eb0/package.json) doesn't include any packaging or publishing scripts, but I tried cloning it myself and running

```zsh
vsce package
code --install-extension vscode-sort-json-1.17.0.vsix
```

...and it installed a perfectly functioning extension in my VSCodium installation. 👍🏼