### PR TITLE
Add ctf0.macros

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -218,6 +218,10 @@
       "repository": "https://github.com/csstools/postcss-language"
     },
     {
+      "id": "ctf0.macros",
+      "repository": "https://github.com/ctf0/macros"
+    },
+    {
       "id": "danielgjackson.auto-dark-mode-windows",
       "repository": "https://github.com/danielgjackson/vscode-auto-dark-mode-windows"
     },


### PR DESCRIPTION
[macros](https://github.com/ctf0/macros) is an MIT-licensed extension that adds support for custom macros.

```bash
vsce package
code --install-extension macros-0.0.4.vsix
```

...is all that's needed to install the extension. 👍🏼