### PR TITLE
Add Color Info extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -139,6 +139,10 @@
       "version": "1.2.1"
     },
     {
+      "id": "bierner.color-info",
+      "repository": "https://github.com/mattbierner/vscode-color-info"
+    },
+    {
       "id": "bltg-team.masm",
       "repository": "https://github.com/9176324/bltg-team.masm"
     },

--- a/extensions.json
+++ b/extensions.json
@@ -140,7 +140,9 @@
     },
     {
       "id": "bierner.color-info",
-      "repository": "https://github.com/mattbierner/vscode-color-info"
+      "repository": "https://github.com/mattbierner/vscode-color-info",
+      "version": "0.5.1",
+      "checkout": "0.5.1"
     },
     {
       "id": "bltg-team.masm",


### PR DESCRIPTION
The Color Info extension by Matt Bierner is [MIT-licensed](https://github.com/mattbierner/vscode-color-info/blob/master/LICENSE) & adds additional information when you hover over a css color.