### PR TITLE
Fix syntax error in extensions.json

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -97,7 +97,7 @@
     {
       "id": "asciidoctor.asciidoctor-vscode",
       "version": "2.8.4",
-      "download:" "https://github.com/asciidoctor/asciidoctor-vscode/releases/download/v2.8.4/asciidoctor-vscode-2.8.4.vsix"
+      "download": "https://github.com/asciidoctor/asciidoctor-vscode/releases/download/v2.8.4/asciidoctor-vscode-2.8.4.vsix"
     },
     {
       "id": "asvetliakov.vscode-neovim",


### PR DESCRIPTION
Currently publish extensions process is broken because of syntax error in extensions.json:
![image](https://user-images.githubusercontent.com/16555289/98208569-28f13400-1f46-11eb-97b5-83b2f9a019cd.png)
