### PR TITLE
Download VSIX for OCaml Platform extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -922,9 +922,8 @@
     },
     {
       "id": "ocamllabs.ocaml-platform",
-      "repository": "https://github.com/ocamllabs/vscode-ocaml-platform.git",
-      "version": "1.4.0",
-      "checkout": "v1.4.0"
+      "download": "https://github.com/ocamllabs/vscode-ocaml-platform/releases/download/v1.4.0/ocaml-platform-1.4.0.vsix",
+      "version": "1.4.0"
     },
     {
       "id": "octref.vetur",


### PR DESCRIPTION
The 1.4.0 version of the OCaml Platform extension is currently broken when downloaded from open-vsx:
https://github.com/eclipse/openvsx/issues/203
https://github.com/ocamllabs/vscode-ocaml-platform/issues/436

The extension has some specific build requirements that would prevent it from building correctly with the current configuration. This PR switches to downloading a released VSIX that is already built.