### PR TITLE
Add vscode-arduino

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1201,7 +1201,7 @@
     },
     {
       "id": "vsciot-vscode.vscode-arduino",
-      "repository": "https://github.com/microsoft/vscode-arduino",
+      "download": "https://github.com/microsoft/vscode-arduino/releases/download/v0.3.4/vscode-arduino-0.3.4.vsix",
       "version": "0.3.4"
     },
     {

--- a/extensions.json
+++ b/extensions.json
@@ -1200,6 +1200,11 @@
       "repository": "https://github.com/vortizhe/vscode-ruby-erb"
     },
     {
+      "id": "vsciot-vscode.vscode-arduino",
+      "repository": "https://github.com/microsoft/vscode-arduino",
+      "version": "0.3.4"
+    },
+    {
       "id": "vscjava.vscode-java-debug",
       "download": "https://github.com/microsoft/vscode-java-debug/releases/download/0.29.0/vscjava.vscode-java-debug-0.29.0.vsix",
       "version": "0.29.0"


### PR DESCRIPTION
License is MIT, see https://github.com/microsoft/vscode-arduino/blob/master/LICENSE.txt.

Entry was created using `node add-extension https://github.com/microsoft/vscode-arduino`.