### PR TITLE
update: Adds godot-vscode-plugin 1.1.2 .vsix

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -446,8 +446,8 @@
     },
     {
       "id": "geequlim.godot-tools",
-      "download": "https://github.com/godotengine/godot-vscode-plugin/releases/download/1.0.1/godot-tools-1.0.1.vsix",
-      "version": "1.0.1"
+      "download": "https://github.com/godotengine/godot-vscode-plugin/releases/download/1.1.2/godot-tools-1.1.2.vsix",
+      "version": "1.1.2"
     },
     {
       "id": "gharveymn.nightswitch-lite",


### PR DESCRIPTION
Previous conversation: https://github.com/open-vsx/publish-extensions/pull/220

Hey @jankeromnes,

I don't know why the pull request closed, while I was fixing the git history, but I've updated my branch with the link to the new `.vsix`. 