### PR TITLE
WIP: Add Ariake Dark theme

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -12,6 +12,10 @@
       "checkout": "v3.8.0"
     },
     {
+      "id": "a-wart.ariake-dark",
+      "repository": "https://github.com/a-wart/ariake-dark"
+    },
+    {
       "id": "aaron-bond.better-comments",
       "repository": "https://github.com/aaron-bond/better-comments"
     },


### PR DESCRIPTION
This is a work-in-progress pull request to add the Ariake Dark theme to Open VSX.

Currently waiting for the author to post a license.

Issue: https://github.com/a-wart/ariake-dark/issues/7

The original theme that this is based on is released under the MIT license (https://github.com/pathtrk/ariake-dark-syntax).

I’ll remove the WIP prefix and leave a comment once the author has added a license.