### PR TITLE
feat(ext-pack): Add all needed extensions in order to publish extension pack

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -397,6 +397,11 @@
       "version": "0.3.0"
     },
     {
+      "id": "fabiospampinato.vscode-open-in-npm",
+      "repository": "https://github.com/fabiospampinato/vscode-open-in-npm.git",
+      "version": "1.0.4"
+    },
+    {
       "id": "felixfbecker.php-debug",
       "download": "https://github.com/felixfbecker/vscode-php-debug/releases/download/v1.13.0/php-debug.vsix",
       "version": "1.13.0"
@@ -552,6 +557,11 @@
       "repository": "https://github.com/iocave/monkey-patch"
     },
     {
+      "id": "ipedrazas.kubernetes-snippets",
+      "repository": "https://github.com/ipedrazas/kubernetes-snippets",
+      "version": "0.1.9"
+    },
+    {
       "id": "itsmajestix.vscode-ti",
       "repository": "https://github.com/ItsMajestiX/VSCode-Ti"
     },
@@ -682,6 +692,10 @@
       "repository": "https://github.com/MagicStack/MagicPython",
       "version": "1.1.1",
       "checkout": "v1.1.1"
+    },
+    {
+      "id": "marcostazi.VS-code-vagrantfile",
+      "repository": "https://github.com/mastazi/VS-code-vagrantfile"
     },
     {
       "id": "marus25.cortex-debug",
@@ -974,6 +988,11 @@
       "prepublish": "npm config set script-shell /bin/bash"
     },
     {
+      "id": "oouo-diogo-perdigao.docthis",
+      "repository": "https://github.com/oouo-diogo-perdigao/vscode-docthis",
+      "version": "0.8.2"
+    },
+    {
       "id": "openfl.lime-vscode-extension",
       "repository": "https://github.com/openfl/lime-vscode-extension"
     },
@@ -995,6 +1014,10 @@
     {
       "id": "pdconsec.vscode-print",
       "repository": "https://github.com/PeterWone/vsc-print"
+    },
+    {
+      "id": "peterj.proto",
+      "repository": "https://github.com/pj3677/vscode-protobuf"
     },
     {
       "id": "pflannery.vscode-versionlens",
@@ -1037,6 +1060,11 @@
       "repository": "https://github.com/reduckted/vscode-gitweblinks",
       "version": "1.9.0",
       "checkout": "v1.9.0"
+    },
+    {
+      "id": "ria.elastic",
+      "repository": "https://github.com/hsen-dev/vscode-elastic.git",
+      "version": "0.13.2"
     },
     {
       "id": "ritwickdey.LiveServer",
@@ -1319,6 +1347,10 @@
       "prepublish": "cd packages/vscode-import-cost && git clean -xdf && npm install"
     },
     {
+      "id": "wmaurer.change-case",
+      "repository": "https://github.com/wmaurer/vscode-change-case"
+    },
+    {
       "id": "Wscats.omi-snippets",
       "repository": "https://github.com/Wscats/omi-snippets"
     },
@@ -1346,6 +1378,11 @@
       "id": "xyz.plsql-language",
       "repository": "https://github.com/zabel-xyz/plsql-language",
       "version": "1.8.2"
+    },
+    {
+      "id": "yatki.vscode-surround",
+      "repository": "https://github.com/yatki/vscode-surround.git",
+      "version": "1.0.2"
     },
     {
       "id": "yzhang.markdown-all-in-one",

--- a/extensions.json
+++ b/extensions.json
@@ -398,8 +398,7 @@
     },
     {
       "id": "fabiospampinato.vscode-open-in-npm",
-      "repository": "https://github.com/fabiospampinato/vscode-open-in-npm.git",
-      "version": "1.0.4"
+      "repository": "https://github.com/fabiospampinato/vscode-open-in-npm"
     },
     {
       "id": "felixfbecker.php-debug",
@@ -558,8 +557,7 @@
     },
     {
       "id": "ipedrazas.kubernetes-snippets",
-      "repository": "https://github.com/ipedrazas/kubernetes-snippets",
-      "version": "0.1.9"
+      "repository": "https://github.com/ipedrazas/kubernetes-snippets"
     },
     {
       "id": "itsmajestix.vscode-ti",
@@ -989,8 +987,7 @@
     },
     {
       "id": "oouo-diogo-perdigao.docthis",
-      "repository": "https://github.com/oouo-diogo-perdigao/vscode-docthis",
-      "version": "0.8.2"
+      "repository": "https://github.com/oouo-diogo-perdigao/vscode-docthis"
     },
     {
       "id": "openfl.lime-vscode-extension",
@@ -1063,8 +1060,7 @@
     },
     {
       "id": "ria.elastic",
-      "repository": "https://github.com/hsen-dev/vscode-elastic.git",
-      "version": "0.13.2"
+      "repository": "https://github.com/hsen-dev/vscode-elastic"
     },
     {
       "id": "ritwickdey.LiveServer",
@@ -1348,7 +1344,9 @@
     },
     {
       "id": "wmaurer.change-case",
-      "repository": "https://github.com/wmaurer/vscode-change-case"
+      "repository": "https://github.com/wmaurer/vscode-change-case",
+      "version": "0.3.2",
+      "checkout": "v0.3.2"
     },
     {
       "id": "Wscats.omi-snippets",
@@ -1381,8 +1379,9 @@
     },
     {
       "id": "yatki.vscode-surround",
-      "repository": "https://github.com/yatki/vscode-surround.git",
-      "version": "1.0.2"
+      "repository": "https://github.com/yatki/vscode-surround",
+      "version": "1.0.2",
+      "checkout": "v1.0.2"
     },
     {
       "id": "yzhang.markdown-all-in-one",


### PR DESCRIPTION
There is a list of all needed extensions that are not exist on Open VSX registry:

- https://github.com/peterj/vscode-protobuf
- https://github.com/wmaurer/vscode-change-case
- https://github.com/mastazi/VS-code-vagrantfile
- https://github.com/ipedrazas/kubernetes-snippets
- https://github.com/Duroktar/vscode-npm-scripts
- https://github.com/yatki/vscode-surround
- https://github.com/hsen-dev/vscode-elastic
- https://github.com/fabiospampinato/vscode-open-in-npm
- https://github.com/oouo-diogo-perdigao/vscode-docthis

Those extensions should exist on registry in order to publish extension pack.
They all have MIT license.