### PR TITLE
Add C/C++ tools Extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1403,6 +1403,12 @@
     {
       "id": "zxh404.vscode-proto3",
       "repository": "https://github.com/zxh0/vscode-proto3"
+    },
+    {
+      "id": "ms-vscode.cpptools",
+      "repository": "https://github.com/microsoft/vscode-cpptools",
+      "checkout": "release",
+      "location": "/Extension"
     }
   ]
 }


### PR DESCRIPTION
Add the official C/C++ extension from MS, which is under the MIT License.