### PR TITLE
Add arcanis.vscode-zipfs

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -95,9 +95,10 @@
     },
     {
       "id": "arcanis.vscode-zipfs",
-      "repository": "https://github.com/yarnpkg/berry.git",
+      "repository": "https://github.com/yarnpkg/berry",
       "version": "2.2.4",
-      "location": "packages/vscode-zipfs/"
+      "checkout": "vscode-zipfs/2.2.4",
+      "location": "packages/vscode-zipfs"
     },
     {
       "id": "arjun.swagger-viewer",

--- a/extensions.json
+++ b/extensions.json
@@ -94,6 +94,12 @@
       "version": "1.0.3"
     },
     {
+      "id": "arcanis.vscode-zipfs",
+      "repository": "https://github.com/yarnpkg/berry.git",
+      "version": "2.2.4",
+      "location": "packages/vscode-zipfs/"
+    },
+    {
       "id": "arjun.swagger-viewer",
       "repository": "https://github.com/arjun-g/vs-swagger-viewer"
     },


### PR DESCRIPTION
This adds arcanis.vscode-zipfs.
The License is [2-Clause-BSD](https://github.com/yarnpkg/berry/blob/master/LICENSE.md).
Upstream doesn't seem to tag, so I didn't add a checkout.
There is an Issue for them to publish themselves, but there wasn't progress so far. Can the yarn project claim the namespace arcanis later, when it's added through here?


