### PR TITLE
Add bierner.docs-view

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -155,6 +155,11 @@
       "checkout": "0.5.1"
     },
     {
+      "id": "bierner.docs-view",
+      "repository": "https://github.com/mattbierner/vscode-docs-view.git",
+      "version": "0.0.8"
+    },
+    {
       "id": "bltg-team.masm",
       "repository": "https://github.com/9176324/bltg-team.masm"
     },

--- a/extensions.json
+++ b/extensions.json
@@ -156,7 +156,7 @@
     },
     {
       "id": "bierner.docs-view",
-      "repository": "https://github.com/mattbierner/vscode-docs-view.git",
+      "repository": "https://github.com/mattbierner/vscode-docs-view",
       "version": "0.0.8"
     },
     {


### PR DESCRIPTION
This adds bierner.docs-view.
I didn't add a checkout, because upstream [added a license](https://github.com/mattbierner/vscode-docs-view/commit/1f93ad0c3931336c30f1fcf1da18a0bad779d15e) after the latest tag 0.0.8. It's now MIT-licensed, but I think legally the 0.0.8 tag is still unlicensed.
 