### PR TITLE
Add prepublish script for vsc-material-theme and vsc-material-theme-icons

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -376,11 +376,13 @@
     },
     {
       "id": "Equinusocio.vsc-material-theme",
-      "repository": "https://github.com/material-theme/vsc-material-theme"
+      "repository": "https://github.com/material-theme/vsc-material-theme",
+      "prepublish": "yarn build"
     },
     {
       "id": "equinusocio.vsc-material-theme-icons",
-      "repository": "https://github.com/material-theme/vsc-material-theme-icons"
+      "repository": "https://github.com/material-theme/vsc-material-theme-icons",
+      "prepublish": "sed -i 's+git@github.com:material-theme/vsc-material-theme-icons-src.git+https://github.com/material-theme/vsc-material-theme-icons-src.git+g' build/get-remote-icons.ts && yarn build"
     },
     {
       "id": "erlang-ls.erlang-ls",


### PR DESCRIPTION
Both vsc-material-theme and vsc-material-theme-icons require `yarn build` to be run before publishing, and this is currently not being done. 

The build script for vsc-material-theme-icons clones the repository material-theme/vsc-material-theme-icons-src. Unfortunately, it tries to clone the repo through ssh, which requires a public key to be present. I'm using sed to make the build script clone the https version of the same repo. 

Should resolve https://github.com/material-theme/vsc-material-theme-icons/issues/158, https://github.com/material-theme/vsc-material-theme/issues/496, and https://github.com/material-theme/vsc-material-theme/issues/507. 