### PR TITLE
refactor(add-extension): Update add-extension.js

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,5 +4,5 @@ root = true
 indent_style = space
 indent_size = 2
 charset = utf-8
-trim_trailing_whitespace = false
+trim_trailing_whitespace = true
 insert_final_newline = false

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,2 +1,6 @@
 tasks:
   - init: npm install
+
+vscode:
+  extensions:
+  - editorconfig.editorconfig

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,2 @@
 tasks:
   - init: npm install
-
-vscode:
-  extensions:
-  - editorconfig.editorconfig

--- a/add-extension.js
+++ b/add-extension.js
@@ -9,214 +9,83 @@
  ********************************************************************************/
 
 // @ts-check
-const fs = require('fs');
 const minimist = require('minimist');
 const ovsx = require('ovsx');
-const path = require('path');
-const util = require('util');
-const semver = require('semver');
 const exec = require('./lib/exec');
-const { DH_UNABLE_TO_CHECK_GENERATOR } = require('constants');
-const readFile = util.promisify(fs.readFile);
-const writeFile = util.promisify(fs.writeFile);
+const { readExtensionsFromFile, addNewExtension, onDidAddExtension, writeToExtensionsFile, fetchExtInfoFromClonedRepo } = require('./lib/utils');
 
-const registry = new ovsx.Registry();
+(async () => {
+  const extensionFilePath = './extensions.json'
+  /**
+   * @type {{
+   *    extensions: {
+   *        id: string,
+   *        repository: string,
+   *        version?: string,
+   *        checkout?: string,
+   *        location?: string,
+   *        prepublish?: string,
+   *        extensionFile?: string,
+   *        download?: string
+   *    }[]
+   * }}
+   */
+  const { extensions } = await readExtensionsFromFile(extensionFilePath)
 
-// don't run this part if this module is not exported 
-// @ts-ignore
-if (!module.parent) {
-  (async () => {
-    const extensionFilePath = './extensions.json'
-    /**
-     * @type {{
-     *    extensions: {
-     *        id: string,
-     *        repository: string,
-     *        version?: string,
-     *        checkout?: string,
-     *        location?: string,
-     *        prepublish?: string,
-     *        extensionFile?: string,
-     *        download?: string
-     *    }[]
-     * }}
-     */
-    const { extensions } = await readExtensionsFromFile(extensionFilePath)
-  
-    const argv = minimist(process.argv.slice(2));
-    if (argv._.length !== (!!argv.download ? 0 : 1)) {
-      console.log(`Usage: node add-extension REPOSITORY [OPTIONS]
-  OPTIONS:
-      --checkout=CHECKOUT
-      --location=LOCATION
-      --prepublish=PREPUBLISH
-      --extensionFile=EXTENSION_FILE
-  
-  Alternative usage: node add-extension --download=VSIX_URL`);
-      process.exitCode = 1;
-      process.exit();
-    }
-  
-    // Handle 'node add-extension --download=VSIX_URL':
-    if (argv.download) {
-      try {
-        await exec('mkdir -p /tmp/vsix');
-        await exec(`wget -O extension.vsix ${argv.download}`, { cwd: '/tmp/vsix' });
-        await exec('unzip -q extension.vsix', { cwd: '/tmp/vsix' });
-        /** @type {{ publisher: string, name: string, version: string }} */
-        const package = await ovsx.readManifest('/tmp/vsix/extension/package.json');
-        ovsx.validateManifest(package)
-        const extension = { id: `${package.publisher}.${package.name}`, download: argv.download, version: package.version };
-        await addNewExtension(extension, package, extensions);
-        onDidAddExtension(extension);
-        await writeToExtensionsFile(extensions, extensionFilePath)
-      } catch (error) {
-        console.error(`[FAIL] Could not add ${argv.download}!`);
-        console.error(error);
-        process.exitCode = -1;
-      } finally {
-        await exec('rm -rf /tmp/vsix');
-        process.exit();
-      }
-    }
-  
-    // Handle 'node add-extension REPOSITORY [OPTIONS]':
-    const repository = argv._[0].replace(/\/*$/, '');
-    const existing = extensions.find(e => e.repository && e.repository.toLowerCase() === repository.toLowerCase() && e.location === argv.location);
-    if (existing) {
-      console.log(`[SKIPPED] Repository already in extensions.json: ${JSON.stringify(existing, null, 2)}`);
-      return;
-    }
-  
+  const argv = minimist(process.argv.slice(2));
+  if (argv._.length !== (!!argv.download ? 0 : 1)) {
+    console.log(`Usage: node add-extension REPOSITORY [OPTIONS]
+OPTIONS:
+    --checkout=CHECKOUT
+    --location=LOCATION
+    --prepublish=PREPUBLISH
+    --extensionFile=EXTENSION_FILE
+
+Alternative usage: node add-extension --download=VSIX_URL`);
+    process.exitCode = 1;
+    process.exit();
+  }
+
+  // Handle 'node add-extension --download=VSIX_URL':
+  if (argv.download) {
     try {
-      // @ts-ignore
-      const { extension, package } = await fetchExtInfoFromClonedRepo(repository, argv)
+      await exec('mkdir -p /tmp/vsix');
+      await exec(`wget -O extension.vsix ${argv.download}`, { cwd: '/tmp/vsix' });
+      await exec('unzip -q extension.vsix', { cwd: '/tmp/vsix' });
+      /** @type {{ publisher: string, name: string, version: string }} */
+      const package = await ovsx.readManifest('/tmp/vsix/extension/package.json');
+      ovsx.validateManifest(package)
+      const extension = { id: `${package.publisher}.${package.name}`, download: argv.download, version: package.version };
       await addNewExtension(extension, package, extensions);
-      await writeToExtensionsFile(extensions, extensionFilePath)
       onDidAddExtension(extension);
+      await writeToExtensionsFile(extensions, extensionFilePath)
     } catch (error) {
-      console.error(`[FAIL] Could not add ${repository}!`);
+      console.error(`[FAIL] Could not add ${argv.download}!`);
       console.error(error);
       process.exitCode = -1;
+    } finally {
+      await exec('rm -rf /tmp/vsix');
+      process.exit();
     }
-  })();
-}
-
-async function fetchExtInfoFromClonedRepo(repository, { checkout, location, extensionFile, prepublish }) {
-  const tmpRepoFolder = '/tmp/repository';
-  
-  try {
-    const { packagePath }  = await cloneRepo(tmpRepoFolder, repository, checkout, location)
-    const package = await ovsx.readManifest(packagePath)
-    if (registry.requiresLicense && !(await ovsx.isLicenseOk(packagePath, package))) {
-      throw new Error(`License must be present, please ask author of extension to add license (${repository})`)
-    } else {
-      ovsx.validateManifest(package)
-    }
-    // Add extension to the list.
-    const extension = { id: `${package.publisher}.${package.name}`, repository, version: package.version };
-    if (checkout) {
-        extension.checkout = checkout;
-    }
-    if (location !== '.') {
-      extension.location = location;
-    }
-    if (prepublish) {
-        extension.prepublish = prepublish;
-    }
-    if (extensionFile) {
-      extension.extensionFile = extensionFile;
-    }
-    return { extension, package }
-  } finally {
-    await exec(`rm -rf ${tmpRepoFolder}`);
-  }
-}
-
-async function cloneRepo(tmpRepoFolder, repository, checkout, location) {
-  if (!new URL(repository)) {
-    throw new Error(`Invalid repository URL: ${repository}`);
   }
 
-  // Clone the repository to determine the extension's latest version.
-  await exec(`git clone --recurse-submodules ${repository} ${tmpRepoFolder}`);
-  if (typeof checkout === 'string') {
-    // Check out the specified Git branch, tag, or commit.
-    await exec(`git checkout ${checkout}`, { cwd: tmpRepoFolder });
-  } else if (checkout === true) {
-    // If --checkout is passed without a value, set its value to the repository's default Git branch.
-    const { stdout: defaultBranch } = await exec(`git rev-parse --abbrev-ref HEAD`, { cwd: tmpRepoFolder });
-    checkout = defaultBranch.trim();
-  }
-
-  // Locate and parse package.json.
-  if (!location) {
-    const { stdout: files } = await exec('ls package.json 2>/dev/null || git ls-files | grep package\\.json', { cwd: '/tmp/repository' });
-    if (!files.trim()) {
-      throw new Error(`No package.json found in repository!`);
-    }
-    const locations = files.trim().split('\n');
-    if (locations.length > 1) {
-      console.warn(`[WARNING] Multiple package.json found in repository, arbitrarily using the first one:\n> ${locations[0]}\n${locations.slice(1).map(l => '  ' + l).join('\n')}`);
-    }
-    location = path.dirname(locations[0]);
-  }
-  return { packagePath: path.join(tmpRepoFolder, location) };
-}
-
-async function ensureNotAlreadyOnOpenVSX(package, registry) {
-  const id = `${package.publisher}.${package.name}`;
-  let metadata;
-  try {
-    metadata = await registry.getMetadata(package.publisher, package.name);
-  } catch (error) {
-    console.warn(`[WARNING] Could not check Open VSX version of ${id}:`);
-    console.warn(error);
+  // Handle 'node add-extension REPOSITORY [OPTIONS]':
+  const repository = argv._[0].replace(/\/*$/, '');
+  const existing = extensions.find(e => e.repository && e.repository.toLowerCase() === repository.toLowerCase() && e.location === argv.location);
+  if (existing) {
+    console.log(`[SKIPPED] Repository already in extensions.json: ${JSON.stringify(existing, null, 2)}`);
     return;
   }
-  if (metadata.error) {
-    console.warn(`[WARNING] Could not check Open VSX version of ${id}:`);
-    console.warn(metadata.error);
-  } else if (metadata.version) {
-    if (semver.gt(metadata.version, package.version)) {
-      throw new Error(`Open VSX already has a more recent version of ${id}: ${metadata.version} > ${package.version}`);
-    }
-    console.warn(`[WARNING] Open VSX already has ${id} in version ${metadata.version}. Adding ${package.version} here anyway.`);
+
+  try {
+    // @ts-ignore
+    const { extension, package } = await fetchExtInfoFromClonedRepo(repository, argv)
+    await addNewExtension(extension, package, extensions);
+    await writeToExtensionsFile(extensions, extensionFilePath)
+    onDidAddExtension(extension);
+  } catch (error) {
+    console.error(`[FAIL] Could not add ${repository}!`);
+    console.error(error);
+    process.exitCode = -1;
   }
-}
-
-async function onDidAddExtension (extension) {
-  console.log(`[OK] Succesfully added new extension: ${JSON.stringify(extension, null, 2)}`);
-}
-
-async function writeToExtensionsFile (extensions, path = './extensions.json') {
-  // Save new extensions list.
-  await writeFile(path, JSON.stringify({ extensions }, null, 2) + '\n', 'utf-8');
-}
-
-async function readExtensionsFromFile (extensionFilePath) {
-  return JSON.parse(await readFile(extensionFilePath, 'utf-8'));
-}
-
-async function addNewExtension(extension, package, extensions) {
-  // Check whether the extension is already published on Open VSX.
-  await ensureNotAlreadyOnOpenVSX(package, registry);
-
-  extensions.push(extension);
-
-  // Sort extensions alphabetically by ID (not case-sensitive).
-  extensions.sort((a, b) => {
-    if (b.id.toLowerCase() > a.id.toLowerCase()) return -1;
-    if (b.id.toLowerCase() < a.id.toLowerCase()) return 1;
-    return 0;
-  });
-}
-
-module.exports = {
-  addNewExtension,
-  onDidAddExtension,
-  writeToExtensionsFile,
-  readExtensionsFromFile,
-  fetchExtInfoFromClonedRepo,
-  cloneRepo
-}
+})();

--- a/add-extension.js
+++ b/add-extension.js
@@ -68,8 +68,7 @@ Alternative usage: node add-extension --download=VSIX_URL`);
       await exec('mkdir -p /tmp/vsix');
       await exec(`wget -O extension.vsix ${argv.download}`, { cwd: '/tmp/vsix' });
       await exec('unzip -q extension.vsix', { cwd: '/tmp/vsix' });
-      /** @type {{ publisher: string, name: string, version: string }} */
-      const package = await ovsx.readManifest('/tmp/vsix/extension/package.json');
+      const package = await ovsx.readManifest('/tmp/vsix/extension');
       ovsx.validateManifest(package)
       const extension = { id: `${package.publisher}.${package.name}`, download: argv.download, version: package.version };
       await addNewExtension(extension, package, extensions);

--- a/add-extension.js
+++ b/add-extension.js
@@ -19,130 +19,138 @@ const exec = require('./lib/exec');
 const readFile = util.promisify(fs.readFile);
 const writeFile = util.promisify(fs.writeFile);
 
-(async () => {
-  /**
-   * @type {{
-   *    extensions: {
-   *        id: string,
-   *        repository: string,
-   *        version?: string,
-   *        checkout?: string,
-   *        location?: string,
-   *        prepublish?: string,
-   *        extensionFile?: string,
-   *        download?: string
-   *    }[]
-   * }}
-   */
-  const { extensions } = JSON.parse(await readFile('./extensions.json', 'utf-8'));
-  const registry = new ovsx.Registry();
+const registry = new ovsx.Registry();
 
-  const argv = minimist(process.argv.slice(2));
-  if (argv._.length !== (!!argv.download ? 0 : 1)) {
-    console.log(`Usage: node add-extension REPOSITORY [OPTIONS]
-OPTIONS:
-    --checkout=CHECKOUT
-    --location=LOCATION
-    --prepublish=PREPUBLISH
-    --extensionFile=EXTENSION_FILE
-
-Alternative usage: node add-extension --download=VSIX_URL`);
-    process.exitCode = 1;
-    process.exit();
-  }
-
-  // Handle 'node add-extension --download=VSIX_URL':
-  if (argv.download) {
-    try {
-      await exec('mkdir -p /tmp/vsix');
-      await exec(`wget -O extension.vsix ${argv.download}`, { cwd: '/tmp/vsix' });
-      await exec('unzip -q extension.vsix', { cwd: '/tmp/vsix' });
-      /** @type {{ publisher: string, name: string, version: string }} */
-      const package = JSON.parse(await readFile('/tmp/vsix/extension/package.json', 'utf-8'));
-      await ensureNotAlreadyOnOpenVSX(package, registry);
-      const extension = { id: `${package.publisher}.${package.name}`, download: argv.download, version: package.version };
-      await addNewExtension(extension, extensions);
-    } catch (error) {
-      console.error(`[FAIL] Could not add ${argv.download}!`);
-      console.error(error);
-      process.exitCode = -1;
-    } finally {
-      await exec('rm -rf /tmp/vsix');
+// don't run this part if this module is not exported 
+// @ts-ignore
+if (!module.parent) {
+  (async () => {
+    const extensionFilePath = './extensions.json'
+    /**
+     * @type {{
+     *    extensions: {
+     *        id: string,
+     *        repository: string,
+     *        version?: string,
+     *        checkout?: string,
+     *        location?: string,
+     *        prepublish?: string,
+     *        extensionFile?: string,
+     *        download?: string
+     *    }[]
+     * }}
+     */
+    const { extensions } = await readExtensionsFromFile(extensionFilePath)
+  
+    const argv = minimist(process.argv.slice(2));
+    if (argv._.length !== (!!argv.download ? 0 : 1)) {
+      console.log(`Usage: node add-extension REPOSITORY [OPTIONS]
+  OPTIONS:
+      --checkout=CHECKOUT
+      --location=LOCATION
+      --prepublish=PREPUBLISH
+      --extensionFile=EXTENSION_FILE
+  
+  Alternative usage: node add-extension --download=VSIX_URL`);
+      process.exitCode = 1;
       process.exit();
     }
-  }
-
-  // Handle 'node add-extension REPOSITORY [OPTIONS]':
-  const repository = argv._[0].replace(/\/*$/, '');
-  const existing = extensions.find(e => e.repository && e.repository.toLowerCase() === repository.toLowerCase() && e.location === argv.location);
-  if (existing) {
-    console.log(`[SKIPPED] Repository already in extensions.json: ${JSON.stringify(existing, null, 2)}`);
-    return;
-  }
-
-  try {
-    if (!new URL(repository)) {
-      throw new Error(`Invalid repository URL: ${repository}`);
-    }
-
-    // Clone the repository to determine the extension's latest version.
-    await exec(`git clone --recurse-submodules ${repository} /tmp/repository`);
-    if (typeof argv.checkout === 'string') {
-        // Check out the specified Git branch, tag, or commit.
-        await exec(`git checkout ${argv.checkout}`, { cwd: '/tmp/repository' });
-    } else if (argv.checkout === true) {
-        // If --checkout is passed without a value, set its value to the repository's default Git branch.
-        const { stdout: defaultBranch } = await exec(`git rev-parse --abbrev-ref HEAD`, { cwd: '/tmp/repository' });
-        argv.checkout = defaultBranch.trim();
-    }
-
-    // Locate and parse package.json.
-    let location = argv.location;
-    if (!location) {
-        const { stdout: files } = await exec('ls package.json 2>/dev/null || git ls-files | grep package\\.json', { cwd: '/tmp/repository' });
-        if (!files.trim()) {
-            throw new Error(`No package.json found in repository!`);
-        }
-        const locations = files.trim().split('\n');
-        if (locations.length > 1) {
-            console.warn(`[WARNING] Multiple package.json found in repository, arbitrarily using the first one:\n> ${locations[0]}\n${locations.slice(1).map(l => '  ' + l).join('\n')}`);
-        }
-        location = path.dirname(locations[0]);
-    }
-    /** @type {{ publisher: string, name: string, version: string }} */
-    const package = JSON.parse(await readFile(path.join('/tmp/repository', location, 'package.json'), 'utf-8'));
-    ['publisher', 'name', 'version'].forEach(key => {
-      if (!(key in package)) {
-        throw new Error(`Expected "${key}" in ${location}/package.json: ${JSON.stringify(package, null, 2)}`);
+  
+    // Handle 'node add-extension --download=VSIX_URL':
+    if (argv.download) {
+      try {
+        await exec('mkdir -p /tmp/vsix');
+        await exec(`wget -O extension.vsix ${argv.download}`, { cwd: '/tmp/vsix' });
+        await exec('unzip -q extension.vsix', { cwd: '/tmp/vsix' });
+        /** @type {{ publisher: string, name: string, version: string }} */
+        const package = JSON.parse(await readFile('/tmp/vsix/extension/package.json', 'utf-8'));
+        validatePackage(package)
+        const extension = { id: `${package.publisher}.${package.name}`, download: argv.download, version: package.version };
+        await addNewExtension(extension, package, extensions);
+        onDidAddExtension(extension);
+        await writeToExtensionsFile(extensions, extensionFilePath)
+      } catch (error) {
+        console.error(`[FAIL] Could not add ${argv.download}!`);
+        console.error(error);
+        process.exitCode = -1;
+      } finally {
+        await exec('rm -rf /tmp/vsix');
+        process.exit();
       }
-    });
+    }
+  
+    // Handle 'node add-extension REPOSITORY [OPTIONS]':
+    const repository = argv._[0].replace(/\/*$/, '');
+    const existing = extensions.find(e => e.repository && e.repository.toLowerCase() === repository.toLowerCase() && e.location === argv.location);
+    if (existing) {
+      console.log(`[SKIPPED] Repository already in extensions.json: ${JSON.stringify(existing, null, 2)}`);
+      return;
+    }
+  
+    try {
+      // @ts-ignore
+      const { extension, package } = await fetchExtInfoFromClonedRepo(repository, argv)
+      await addNewExtension(extension, package, extensions);
+      await writeToExtensionsFile(extensions, extensionFilePath)
+      onDidAddExtension(extension);
+    } catch (error) {
+      console.error(`[FAIL] Could not add ${repository}!`);
+      console.error(error);
+      process.exitCode = -1;
+    }
+  })();
+}
 
-    // Check whether the extension is already published on Open VSX.
-    await ensureNotAlreadyOnOpenVSX(package, registry);
-
-    // Add extension to the list.
-    const extension = { id: `${package.publisher}.${package.name}`, repository, version: package.version };
-    if (argv.checkout) {
-        extension.checkout = argv.checkout;
-    }
-    if (location !== '.') {
-      extension.location = location;
-    }
-    if (argv.prepublish) {
-        extension.prepublish = argv.prepublish;
-    }
-    if (argv.extensionFile) {
-      extension.extensionFile = argv.extensionFile;
-    }
-    await addNewExtension(extension, extensions);
-  } catch (error) {
-    console.error(`[FAIL] Could not add ${repository}!`);
-    console.error(error);
-    process.exitCode = -1;
-  } finally {
-    await exec('rm -rf /tmp/repository');
+async function fetchExtInfoFromClonedRepo (repository, { checkout, location, extensionFile, prepublish }) {
+  if (!new URL(repository)) {
+    throw new Error(`Invalid repository URL: ${repository}`);
   }
-})();
+
+  const tmpRepoFolder = '/tmp/repository'
+  // Clone the repository to determine the extension's latest version.
+  await exec(`git clone --recurse-submodules ${repository} /tmp/repository`);
+  if (typeof checkout === 'string') {
+      // Check out the specified Git branch, tag, or commit.
+      await exec(`git checkout ${checkout}`, { cwd: tmpRepoFolder });
+  } else if (checkout === true) {
+      // If --checkout is passed without a value, set its value to the repository's default Git branch.
+      const { stdout: defaultBranch } = await exec(`git rev-parse --abbrev-ref HEAD`, { cwd: tmpRepoFolder });
+      checkout = defaultBranch.trim();
+  }
+
+  // Locate and parse package.json.
+  if (!location) {
+      const { stdout: files } = await exec('ls package.json 2>/dev/null || git ls-files | grep package\\.json', { cwd: tmpRepoFolder });
+      if (!files.trim()) {
+          throw new Error(`No package.json found in repository!`);
+      }
+      const locations = files.trim().split('\n');
+      if (locations.length > 1) {
+          console.warn(`[WARNING] Multiple package.json found in repository, arbitrarily using the first one:\n> ${locations[0]}\n${locations.slice(1).map(l => '  ' + l).join('\n')}`);
+      }
+      location = path.dirname(locations[0]);
+  }
+  /** @type {{ publisher: string, name: string, version: string }} */
+  const package = JSON.parse(await readFile(path.join(tmpRepoFolder, location, 'package.json'), 'utf-8'));
+  validatePackage(package)
+
+  // Add extension to the list.
+  const extension = { id: `${package.publisher}.${package.name}`, repository, version: package.version };
+  if (checkout) {
+      extension.checkout = checkout;
+  }
+  if (location !== '.') {
+    extension.location = location;
+  }
+  if (prepublish) {
+      extension.prepublish = prepublish;
+  }
+  if (extensionFile) {
+    extension.extensionFile = extensionFile;
+  }
+  await exec('rm -rf /tmp/repository');
+  return { extension, package }
+}
 
 async function ensureNotAlreadyOnOpenVSX(package, registry) {
   const id = `${package.publisher}.${package.name}`;
@@ -165,7 +173,31 @@ async function ensureNotAlreadyOnOpenVSX(package, registry) {
   }
 }
 
-export async function addNewExtension(extension, extensions) {
+async function onDidAddExtension (extension) {
+  console.log(`[OK] Succesfully added new extension: ${JSON.stringify(extension, null, 2)}`);
+}
+
+async function writeToExtensionsFile (extensions, path = './extensions.json') {
+  // Save new extensions list.
+  await writeFile(path, JSON.stringify({ extensions }, null, 2) + '\n', 'utf-8');
+}
+
+async function readExtensionsFromFile (extensionFilePath) {
+  return JSON.parse(await readFile(extensionFilePath, 'utf-8'));
+}
+
+function validatePackage (package) {
+  ['publisher', 'name', 'version'].forEach(key => {
+    if (!(key in package)) {
+      throw new Error(`Expected "${key}" in ${location}/package.json: ${JSON.stringify(package, null, 2)}`);
+    }
+  });
+}
+
+async function addNewExtension(extension, package, extensions) {
+  // Check whether the extension is already published on Open VSX.
+  await ensureNotAlreadyOnOpenVSX(package, registry);
+
   extensions.push(extension);
 
   // Sort extensions alphabetically by ID (not case-sensitive).
@@ -174,8 +206,12 @@ export async function addNewExtension(extension, extensions) {
     if (b.id.toLowerCase() < a.id.toLowerCase()) return 1;
     return 0;
   });
+}
 
-  // Save new extensions list.
-  await writeFile('./extensions.json', JSON.stringify({ extensions }, null, 2) + '\n', 'utf-8');
-  console.log(`[OK] Succesfully added new extension: ${JSON.stringify(extension, null, 2)}`);
+module.exports = {
+  addNewExtension,
+  onDidAddExtension,
+  writeToExtensionsFile,
+  readExtensionsFromFile,
+  fetchExtInfoFromClonedRepo
 }

--- a/add-extension.js
+++ b/add-extension.js
@@ -165,7 +165,7 @@ async function ensureNotAlreadyOnOpenVSX(package, registry) {
   }
 }
 
-async function addNewExtension(extension, extensions) {
+export async function addNewExtension(extension, extensions) {
   extensions.push(extension);
 
   // Sort extensions alphabetically by ID (not case-sensitive).

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,129 @@
+// @ts-check
+const fs = require('fs');
+const path = require('path');
+const util = require('util');
+const ovsx = require('ovsx');
+const semver = require('semver');
+const exec = require('./exec');
+const readFile = util.promisify(fs.readFile);
+const writeFile = util.promisify(fs.writeFile);
+const registry = new ovsx.Registry();
+
+async function fetchExtInfoFromClonedRepo(repository, { checkout, location, extensionFile, prepublish }) {
+  const tmpRepoFolder = '/tmp/repository';
+  
+  try {
+    const { packagePath }  = await cloneRepo(tmpRepoFolder, repository, checkout, location)
+    const package = await ovsx.readManifest(packagePath)
+    if (registry.requiresLicense && !(await ovsx.isLicenseOk(packagePath, package))) {
+      throw new Error(`License must be present, please ask author of extension to add license (${repository})`)
+    } else {
+      ovsx.validateManifest(package)
+    }
+    // Add extension to the list.
+    const extension = { id: `${package.publisher}.${package.name}`, repository, version: package.version };
+    if (checkout) {
+        extension.checkout = checkout;
+    }
+    if (location !== '.') {
+      extension.location = location;
+    }
+    if (prepublish) {
+        extension.prepublish = prepublish;
+    }
+    if (extensionFile) {
+      extension.extensionFile = extensionFile;
+    }
+    return { extension, package }
+  } finally {
+    await exec(`rm -rf ${tmpRepoFolder}`);
+  }
+}
+
+async function ensureNotAlreadyOnOpenVSX(package, registry) {
+  const id = `${package.publisher}.${package.name}`;
+  let metadata;
+  try {
+    metadata = await registry.getMetadata(package.publisher, package.name);
+  } catch (error) {
+    console.warn(`[WARNING] Could not check Open VSX version of ${id}:`);
+    console.warn(error);
+    return;
+  }
+  if (metadata.error) {
+    console.warn(`[WARNING] Could not check Open VSX version of ${id}:`);
+    console.warn(metadata.error);
+  } else if (metadata.version) {
+    if (semver.gt(metadata.version, package.version)) {
+      throw new Error(`Open VSX already has a more recent version of ${id}: ${metadata.version} > ${package.version}`);
+    }
+    console.warn(`[WARNING] Open VSX already has ${id} in version ${metadata.version}. Adding ${package.version} here anyway.`);
+  }
+}
+
+async function onDidAddExtension (extension) {
+  console.log(`[OK] Succesfully added new extension: ${JSON.stringify(extension, null, 2)}`);
+}
+
+async function writeToExtensionsFile (extensions, path = './extensions.json') {
+  // Save new extensions list.
+  await writeFile(path, JSON.stringify({ extensions }, null, 2) + '\n', 'utf-8');
+}
+
+async function readExtensionsFromFile (extensionFilePath) {
+  return JSON.parse(await readFile(extensionFilePath, 'utf-8'));
+}
+
+async function addNewExtension(extension, package, extensions) {
+  // Check whether the extension is already published on Open VSX.
+  await ensureNotAlreadyOnOpenVSX(package, registry);
+
+  extensions.push(extension);
+
+  // Sort extensions alphabetically by ID (not case-sensitive).
+  extensions.sort((a, b) => {
+    if (b.id.toLowerCase() > a.id.toLowerCase()) return -1;
+    if (b.id.toLowerCase() < a.id.toLowerCase()) return 1;
+    return 0;
+  });
+}
+
+async function cloneRepo(tmpRepoFolder, repository, checkout, location) {
+  if (!new URL(repository)) {
+    throw new Error(`Invalid repository URL: ${repository}`);
+  }
+
+  // Clone the repository to determine the extension's latest version.
+  await exec(`git clone --recurse-submodules ${repository} ${tmpRepoFolder}`);
+  if (typeof checkout === 'string') {
+    // Check out the specified Git branch, tag, or commit.
+    await exec(`git checkout ${checkout}`, { cwd: tmpRepoFolder });
+  } else if (checkout === true) {
+    // If --checkout is passed without a value, set its value to the repository's default Git branch.
+    const { stdout: defaultBranch } = await exec(`git rev-parse --abbrev-ref HEAD`, { cwd: tmpRepoFolder });
+    checkout = defaultBranch.trim();
+  }
+
+  // Locate and parse package.json.
+  if (!location) {
+    const { stdout: files } = await exec('ls package.json 2>/dev/null || git ls-files | grep package\\.json', { cwd: '/tmp/repository' });
+    if (!files.trim()) {
+      throw new Error(`No package.json found in repository!`);
+    }
+    const locations = files.trim().split('\n');
+    if (locations.length > 1) {
+      console.warn(`[WARNING] Multiple package.json found in repository, arbitrarily using the first one:\n> ${locations[0]}\n${locations.slice(1).map(l => '  ' + l).join('\n')}`);
+    }
+    location = path.dirname(locations[0]);
+  }
+  return { packagePath: path.join(tmpRepoFolder, location) };
+}
+
+module.exports = {
+  addNewExtension,
+  onDidAddExtension,
+  writeToExtensionsFile,
+  readExtensionsFromFile,
+  fetchExtInfoFromClonedRepo,
+  cloneRepo
+}


### PR DESCRIPTION
Export a few functions in order to make possible usage of this module by external packages, it will allow to create external tools to automate process of migration extension packs that usually contain a bunch of not published extensions to Open VSX.

Use case: 
```js
const { addNewExtension, onDidAddExtension, writeToExtensionsFile, readExtensionsFromFile, fetchExtInfoFromClonedRepo } = require('./add-extension')

const start = async () => {
    const extensionsFile = './extensions.json'
    const { extensions } = await readExtensionsFromFile(extensionsFile)
    const repos = ['https://github.com/oguhpereira/vscode-spotify-theme', 'https://github.com/whizkydee/vscode-palenight-theme']

    const addedExtensions = []
    for (const repository of repos) {
        const { extension, package } = await fetchExtInfoFromClonedRepo(repository, {})
        await addNewExtension(extension, package, extensions);
        addedExtensions.push(extension)
    }
    await writeToExtensionsFile(extensions, extensionsFile)
    addedExtensions.forEach(extension => onDidAddExtension(extension))
}

start()
```