### PR TITLE
Patch repo URL in package.json, as git+https is not allowed

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -108,7 +108,8 @@
       "repository": "https://github.com/yarnpkg/berry",
       "version": "2.2.4",
       "checkout": "vscode-zipfs/2.2.4",
-      "location": "packages/vscode-zipfs"
+      "location": "packages/vscode-zipfs",
+      "prepublish": "sed -ri \"s_git\\+https://_https://_g\" package.json"
     },
     {
       "id": "arjun.swagger-viewer",

--- a/extensions.json
+++ b/extensions.json
@@ -109,7 +109,7 @@
       "version": "2.2.4",
       "checkout": "vscode-zipfs/2.2.4",
       "location": "packages/vscode-zipfs",
-      "prepublish": "sed -ri \"s_git\\+https://_https://_g\" package.json"
+      "prepublish": "sed -ri \"s_ssh://git@github.com/yarnpkg/berry.git_https://github.com/yarnpkg/berry_g\" package.json"
     },
     {
       "id": "arjun.swagger-viewer",


### PR DESCRIPTION
This is a follow-up to #251, as it was already merged.
The server doesn't accept the repo URL in the `package.json`, as it uses the `git+https` scheme. The prepublish step rewrites that to `https`, which is also valid.