### PR TITLE
Add jebbs.plantuml

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -665,6 +665,13 @@
       "version": "1.2.3"
     },
     {
+      "id": "jebbs.plantuml",
+      "version": "2.14.0",
+      "checkout": "v2.14.0",
+      "repository": "https://github.com/qjebbs/vscode-plantuml.git",
+      "prepublish": "wget -O plantuml.zip https://sourceforge.net/projects/plantuml/files/1.2021.0/plantuml-jar-mit-1.2021.0.zip/download && unzip plantuml.zip && rm plantuml.zip && mv COPYING COPYING.plantuml-jar"
+    },
+    {
       "id": "jock.svg",
       "repository": "https://github.com/lishu/vscode-svg2",
       "version": "1.4.3"


### PR DESCRIPTION
By trial-and-error I came to the conclusion that this extension requires one to
add an official "plantuml.jar" in the extension's root, that will be used for
local, serverless rendering. This apparently does not happen automatically.

That plantuml.jar is available under a few different licenses. I chosed the MIT
one, to match this extension's license. When the zip file is extracted a "COPYING"
file is created along with plantuml.jar, that documents its provenamce and license.
For clarity I rename this file to COPYING.plantuml-jar and leave it in place to be
packaged along with the extension.

Here's where the URL used to fetch plantuml.jar comes from:

Start at the official PlantUML download page:
https://plantuml.com/download
Chose the MIT-version at the bottom of the page and copy the sourceforge link.
At the time of writing it is:
http://sourceforge.net/projects/plantuml/files/plantuml-jar-mit-1.2021.0.zip/download

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>