### PR TITLE
feat(add-extension):  Add license check

### DIFF
--- a/add-extension.js
+++ b/add-extension.js
@@ -115,6 +115,8 @@ Alternative usage: node add-extension --download=VSIX_URL`);
     const package = JSON.parse(await readFile(packagePath, 'utf-8'));
     if (registry.requiresLicense && !(await ovsx.isLicenseOk(packagePath, package))) {
       throw new Error(`License must be present, please ask author of extension to add license (${repository})`)
+    } else {
+      ovsx.validateManifest(package)
     }
 
     // Check whether the extension is already published on Open VSX.

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "download": "^8.0.0",
     "minimist": "^1.2.5",
-    "ovsx": "0.1.0-next.e000fdb",
+    "ovsx": "0.1.0-next.97d460c",
     "semver": "^7.1.3"
   },
   "devDependencies": {}


### PR DESCRIPTION
Added license check to prevent adding extensions that don't contain license but required by https://open-vsx.org

How to test it out?

```bash
$ npm install 
$ npm run add -- https://github.com/octref/polacode
```

Output:
```bash
> publish-to-open-vsx@0.0.0 add /Users/mark/Projects/lab/Github/publish-extensions
> node add-extension "https://github.com/octref/polacode"

Running: git clone --recurse-submodules https://github.com/octref/polacode /tmp/repository
Running: ls package.json 2>/dev/null || git ls-files | grep package\.json
[FAIL] Could not add https://github.com/octref/polacode!
Error: License must be present, please ask author of extension to add license (https://github.com/octref/polacode)
    at /Users/mark/Projects/lab/Github/publish-extensions/add-extension.js:117:13
Running: rm -rf /tmp/repository
npm ERR! code ELIFECYCLE
npm ERR! errno 255
npm ERR! publish-to-open-vsx@0.0.0 add: `node add-extension "https://github.com/octref/polacode"`
npm ERR! Exit status 255
npm ERR! 
npm ERR! Failed at the publish-to-open-vsx@0.0.0 add script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/mark/.npm/_logs/2021-01-18T17_12_29_431Z-debug.log
```

Extension doesn't contain license on the root of folder, license field is not specified in package.json thus this command fail.
It works as expected.

It will help contributors to get feedback instantly about license requirements, thus new pull requests with extensions like that will be not be merged anymore.