### PR TITLE
add eamodio/vscode-gitlens

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -386,6 +386,12 @@
       "repository": "https://github.com/dylan-lang/vscode-dylan"
     },
     {
+      "id": "eamodio.vscode-gitlens",
+      "repository": "https://github.com/eamodio/vscode-gitlens",
+      "version": "10.2.3",
+      "checkout": "v10.2.3"
+    },
+    {
       "id": "ecmel.vscode-html-css",
       "repository": "https://github.com/ecmel/vscode-html-css",
       "version": "1.8.0",


### PR DESCRIPTION
Stated license: MIT

I picked version 10.2.3 because it's the latest version that would work in recent Theia applications, according to the extension's "engines.vscode". More recent versions use new vscode extensions APIs that are beyond what the Theia framework currently support, and so do not work (yet).

Signed-off-by: Marc Dumais <marc.dumais@ericsson.com>