### PR TITLE
Add Jupyter extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1037,6 +1037,14 @@
       "version": "2020.12.424452561"
     },
     {
+      "id": "ms-toolsai.jupyter",
+      "repository": "https://github.com/microsoft/vscode-jupyter",
+      "version": "2020.12.1",
+      "checkout": "2020.12.1",
+      "prepublish": "PIP_USER=no python3 -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade -r requirements.txt && npm run package",
+      "extensionFile": "ms-toolsai-jupyter-insiders.vsix"
+    },
+    {
       "id": "ms-vscode.atom-keybindings",
       "repository": "https://github.com/Microsoft/vscode-atom-keybindings",
       "version": "3.0.6",


### PR DESCRIPTION
This extension is a dependency for recent versions of ms-python.python.
Adding this should fix the publishing error for the Python extension.

The prepublish step is taken from the extension's CONTRIBUTE.md file.
PIP_USER=no is added to prevent its presence otherwise to intefere with
-t flag.

ms-toolsai.jupyter is available under MIT license.