### PR TITLE
Add Ionide F# extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -633,6 +633,10 @@
       "repository": "https://github.com/iocave/monkey-patch"
     },
     {
+      "id": "Ionide.Ionide-fsharp",
+      "repository": "https://github.com/ionide/ionide-vscode-fsharp"
+    },
+    {
       "id": "ipedrazas.kubernetes-snippets",
       "repository": "https://github.com/ipedrazas/kubernetes-snippets"
     },


### PR DESCRIPTION
Hi,

Would it be possible to add the `Ionide.Ionide-Fsharp` extension? License is [MIT](https://github.com/alefragnani/vscode-project-manager/blob/v11.3.0/LICENSE.md)

One caveat is that it has an `"extensionDependency"` on a dependency that is not available on open-vsx:
```
	"extensionDependencies": [
		"ms-dotnettools.csharp"
	],
```
https://github.com/ionide/ionide-vscode-fsharp/blob/200e9484fc6ebf2dfe777ee276021517b7929c4e/release/package.json#L1568

A possible 'solution' is to remap `ms-dotnettools.csharp` to the open-vsx equivalent - `muhammad-sammy.csharp`, but perhaps you've encountered this before and have a more robust solution. Of course, the ideal would be to have the owner publish to open-vsx.

Related to https://github.com/onivim/oni2/issues/2974

Thank you!