### PR TITLE
Add shd101wyy.markdown-preview-enhanced

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1298,6 +1298,12 @@
       "repository": "https://github.com/shardulm94/vscode-trailingspaces"
     },
     {
+      "id": "shd101wyy.markdown-preview-enhanced",
+      "repository": "https://github.com/shd101wyy/vscode-markdown-preview-enhanced",
+      "version": "0.5.16",
+      "checkout": "v0.5.16"
+    },
+    {
       "id": "shinichi-takii.sql-bigquery",
       "repository": "https://github.com/shinichi-takii/vscode-language-sql-bigquery",
       "version": "1.4.0",


### PR DESCRIPTION
The creator of the project hasn't reacted to the issue to publish their extension to Open VSX themselves in a while (see https://github.com/shd101wyy/vscode-markdown-preview-enhanced/issues/426).

Stated license: [University of Illinois/NCSA](https://github.com/shd101wyy/vscode-markdown-preview-enhanced/blob/master/LICENSE.md)