### PR TITLE
Improve automation in 'add-extension' and 'upgrade-extension' helper scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,18 @@ Click the button below to start a [Gitpod](https://gitpod.io) workspace where yo
 
 ## Publishing Options
 
-Here is the expected format of an [`extensions.json`](./extensions.json) entry:
+The best way to add an extension here is to open this repository in Gitpod (using the blue button above) and to run this helper script:
+
+```bash
+node add-extension $REPOSITORY_URL --checkout
+```
+
+Notes:
+- Simply replace `$REPOSITORY_URL` with the extension's actual repository URL
+- This will update `extensions.json` automatically, which you can commit to send a Pull Request
+- Adding `--checkout` (without an explicit value) will auto-detect the latest available Git release tag or branch
+
+If you're curious, here is the expected format of an [`extensions.json`](./extensions.json) entry:
 
 ```js
     {

--- a/add-extension.js
+++ b/add-extension.js
@@ -145,13 +145,16 @@ Alternative usage: node add-extension --download=VSIX_URL`);
     // Add extension to the list.
     const extension = { id: `${package.publisher}.${package.name}`, repository, version: package.version };
     if (argv.checkout) {
-        extension.checkout = argv.checkout;
+      extension.checkout = argv.checkout;
+    } else {
+      // No need to pin a specific version if we're not also using "checkout".
+      delete extension.version;
     }
     if (location !== '.') {
       extension.location = location;
     }
     if (argv.prepublish) {
-        extension.prepublish = argv.prepublish;
+      extension.prepublish = argv.prepublish;
     }
     if (argv.extensionFile) {
       extension.extensionFile = argv.extensionFile;

--- a/add-extension.js
+++ b/add-extension.js
@@ -53,7 +53,7 @@ Alternative usage: node add-extension --download=VSIX_URL`);
     process.exit();
   }
 
-  const repository = (argv._[0] || '').replace(/\/*$/, '');
+  const repository = (argv._[0] || '').replace(/(\.git)?\/*$/, '');
 
   // If possible, always prefer re-publishing an official VSIX release over trying to re-package ourselves.
   if (repository && !argv.download) {

--- a/lib/github-scraper.js
+++ b/lib/github-scraper.js
@@ -7,7 +7,7 @@ exports.findLatestVSIXRelease = async function (repository) {
   console.log(`Scraping ${releasesUrl} to check for updates...`);
   const releases = await get(releasesUrl);
   const matches = releases.match(/\/releases\/download\/[-._a-zA-Z0-9\/%]*\.vsix/g) || [];
-  const latestVSIXRelease = matches.filter(release => !/(nightly|-rc|-alpha|-dev|-next|-[iI]nsider|-beta)/.test(release)).shift();
+  const latestVSIXRelease = matches.filter(release => !/(nightly|-rc|-alpha|-dev|-next|-[iI]nsider|-beta|-pre)/.test(release)).shift();
   if (!latestVSIXRelease) {
     return null;
   }

--- a/lib/github-scraper.js
+++ b/lib/github-scraper.js
@@ -1,0 +1,37 @@
+
+// @ts-check
+const https = require('https');
+
+exports.findLatestVSIXRelease = async function (repository) {
+  const releasesUrl = repository + '/releases';
+  console.log(`Scraping ${releasesUrl} to check for updates...`);
+  const releases = await get(releasesUrl);
+  const matches = releases.match(/\/releases\/download\/[-._a-zA-Z0-9\/%]*\.vsix/g) || [];
+  const latestVSIXRelease = matches.filter(release => !/(nightly|-rc|-alpha|-dev|-next|-[iI]nsider|-beta)/.test(release)).shift();
+  if (!latestVSIXRelease) {
+    return null;
+  }
+  return repository + latestVSIXRelease;
+}
+
+function get (url) {
+  return new Promise((resolve, reject) => {
+    https.get(url, res => {
+      if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+        // Follow HTTP redirections
+        get(res.headers.location).then(resolve, reject);
+        return;
+      }
+      if (res.statusCode >= 400) {
+        reject(new Error(`Couldn't get ${url} - Response status: ${res.statusCode}`));
+        return;
+      }
+      let body = '';
+      res.on('data', chunk => { body += chunk; });
+      res.on('error', error => { reject(error); });
+      res.on('end', () => { resolve(body); });
+    }).on('error', error => {
+      reject(error);
+    });
+  });
+}

--- a/upgrade-extensions.js
+++ b/upgrade-extensions.js
@@ -48,11 +48,7 @@ const dontUpgrade = [
     await writeFile('./extensions.json', JSON.stringify({ extensions: extensionsToNotUpgrade }, null, 2) + '\n', 'utf-8');
 
     for (const extension of extensionRepositoriesToUpgrade) {
-      let command = 'node add-extension ' + extension.repository;
-      if (extension.checkout) {
-          // Since we're upgrading, don't use the currently pinned Git branch, tag, or commit. Use the default Git branch instead.
-          command += ' --checkout';
-      }
+      let command = 'node add-extension ' + extension.repository + ' --checkout'; // Always try to auto-detect a suitable "checkout" value.
       if (extension.location) {
           command += ' --location=' + JSON.stringify(extension.location);
       }
@@ -80,7 +76,11 @@ const dontUpgrade = [
             // This extension likely wasn't actually upgraded, leave it as is.
             continue;
         }
-        if (upgradedExtension.version && upgradedExtension.version !== originalExtension.version && !upgradedExtension.checkout && !upgradedExtension.download) {
+        if (upgradedExtension.download) {
+            // If we're using (or have switched to) VSIX re-publishing, the following heuristics are unhelpful.
+            continue;
+        }
+        if (upgradedExtension.version && upgradedExtension.version !== originalExtension.version && !upgradedExtension.checkout) {
             // If "version" was bumped, but we're publishing from the default branch, it's probably better to just unpin the version.
             delete upgradedExtension.version;
         }


### PR DESCRIPTION
Improvements:
- `node add-extension` will automatically use the latest `.vsix` GitHub Release if available (even if `--download` isn't specified)
- `node add-extension` will by default no longer add extensions with just a `version` but no `checkout` (needed manual fixup to add a `checkout` or remove the `version`)
- `node add-extension --checkout` (without explicit value) will auto-detect a suitable release tag if available (e.g. if `version` is `1.0.0`, and a `v1.0.0` tag is available in the repo, that one will be picked)
- Encourage all users to use `node add-extension REPO --checkout` in the README.md
- `node add-extension` will auto-strip `.git` suffixes from repository URLs

These improvements make `node add-extension` just do the right thing most of the time, and greatly reduce the false positives in `node upgrade-extensions`, thus making the lives of contributors and maintainers much easier.