### PR TITLE
Build ms-python.python from source to avoid depending on Jupyter

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1036,9 +1036,9 @@
     {
       "id": "ms-python.python",
       "repository": "https://github.com/microsoft/vscode-python",
-      "version": "2021.1.502429796+nojupyter",
-      "checkout": "2021.1.502429796",
-      "prepublish": "%SELF%/prepublish-scripts/ms-python.python.sh 502429796",
+      "version": "2021.2.576481509+nojupyter",
+      "checkout": "2021.2.576481509",
+      "prepublish": "%SELF%/prepublish-scripts/ms-python.python.sh 576481509",
       "extensionFile": "ms-python-insiders.vsix"
     },
     {

--- a/extensions.json
+++ b/extensions.json
@@ -1035,8 +1035,11 @@
     },
     {
       "id": "ms-python.python",
-      "download": "https://github.com/microsoft/vscode-python/releases/download/2021.1.502429796/ms-python-release.vsix",
-      "version": "2021.1.502429796"
+      "repository": "https://github.com/microsoft/vscode-python",
+      "version": "2021.1.502429796+nojupyter",
+      "checkout": "2021.1.502429796",
+      "prepublish": "%SELF%/prepublish-scripts/ms-python.python.sh 502429796",
+      "extensionFile": "ms-python-insiders.vsix"
     },
     {
       "id": "ms-vscode.atom-keybindings",

--- a/prepublish-scripts/ms-python.python.sh
+++ b/prepublish-scripts/ms-python.python.sh
@@ -1,0 +1,48 @@
+#!/bin/sh -e
+
+# Copyright (c) 2020 Ratchanan Srirattanamet and others
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License v. 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0.
+
+# SPDX-License-Identifier: EPL-2.0
+
+# This script is based on vscode-python's GitHub Actions, and assumes that
+# the current directory is the repository.
+
+# The script expects the user to pass in the build version.
+ORIG_BUILD_VERSION=$1
+if [ -z "$ORIG_BUILD_VERSION" ]; then
+    echo "Usage: $0 <Original build version>"
+    exit 1
+fi
+
+# Just in case
+export PIP_USER=no
+
+# Create a VirtualEnv for installing extension's Python dependencies
+VENV=$(mktemp -d)
+trap 'ret=$?; rm -rf $VENV; exit $?' INT TERM HUP QUIT
+
+python -m venv "$VENV"
+# shellcheck source=/dev/null
+. "${VENV}/bin/activate"
+
+# Install the extension's Python dependencies
+python -m pip install wheel
+
+python -m pip --disable-pip-version-check install -t ./pythonFiles/lib/python --no-cache-dir --implementation py --no-deps --upgrade -r requirements.txt
+
+python -m pip --disable-pip-version-check install -r build/debugger-install-requirements.txt
+python ./pythonFiles/install_debugpy.py
+
+# Now update the build number. To make this version unique, we append a suffix.
+BUILD_VERSION="${ORIG_BUILD_VERSION}+nojupyter"
+npm run updateBuildNumber -- --buildNumber "$BUILD_VERSION"
+
+# At this point, the GitHub Actions would update the extension dependencies so that
+# it depends on Jupyter extension. However, the whole point of re-building this
+# is so that we don't depend on it, so let's skip that and do the last step: build!
+npm run package
+
+# Finished. The extension file is available at ms-python-insiders.vsix

--- a/publish-extensions.js
+++ b/publish-extensions.js
@@ -36,6 +36,9 @@ const readFile = util.promisify(fs.readFile);
   const { extensions } = JSON.parse(await readFile('./extensions.json', 'utf-8'));
   const registry = new ovsx.Registry();
 
+  // Used to substitute the path in prepublish script.
+  const cwd = process.cwd();
+
   // Also install extensions' devDependencies when using `npm install` or `yarn install`.
   process.env.NODE_ENV = 'development';
 
@@ -120,7 +123,8 @@ const readFile = util.promisify(fs.readFile);
         });
         await exec(`${yarn ? 'yarn' : 'npm'} install`, { cwd: '/tmp/repository' });
         if (extension.prepublish) {
-            await exec(extension.prepublish, { cwd: '/tmp/repository' })
+            const script = extension.prepublish.replace('%SELF%', cwd);
+            await exec(script, { cwd: '/tmp/repository' })
         }
 
         // Publish the extension.


### PR DESCRIPTION
While we wait for Microsoft to clear up [if Open-VSX can distribute rebuilt-from-source Jupyter extension](https://github.com/microsoft/vscode-jupyter/issues/4814), it turns out that if we compile Python extension from source, we can exclude a step that adds the Jupyter extension as a dependency. So, this PR do just that.

As the steps to build the extension for distribution is quite long (it involves installing a few Python dependencies), I decided to factor them out to a dedicated script and refers to it in the `prePublish step`. As this requires referring back to this repo, an ability to do so is added to `publish-extension.js`.

I've tested the extension built using the script myself on [Coder's Code-server](https://github.com/cdr/code-server). The extension seems to still provide expected functionality, with (of course) Jupyter notebook support removed. This should allow Open-VSX users to have an up-to-date Python extension again.

Related: #269 