### PR TITLE
Fix namespace of Symfony-code-snippets extension.

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1107,7 +1107,7 @@
       "repository": "https://github.com/vshaxe/vshaxe.git"
     },
     {
-      "id": "nalabdou.Symfony-code-snippets",
+      "id": "nadim-vscode.Symfony-code-snippets",
       "repository": "https://github.com/nalabdou/Symfony-code-snippets"
     },
     {


### PR DESCRIPTION
It is nadim-vscode instead of nalabdou. 
Fixes the bad namespace introduced in c61f9ccad7dac6da445ad404384c5d586bd0650e .