### PR TITLE
vscode-makefile-tools added

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1061,6 +1061,11 @@
       "extensionFile": "dist/js-debug.vsix"
     },
     {
+      "id": "ms-vscode.makefile-tools",
+      "download": "https://github.com/microsoft/vscode-makefile-tools/releases/download/v0.2.0/makefile-tools.vsix",
+      "version": "0.2.0"
+    },
+    {
       "id": "ms-vscode.node-debug",
       "repository": "https://github.com/microsoft/vscode-node-debug",
       "version": "1.44.8",


### PR DESCRIPTION
`node add-extension` created the download entry which is documented as "should be used if building is not feasible":

```json
"download": "https://github.com/microsoft/vscode-makefile-tools/releases/download/v0.2.0/makefile-tools.vsix"
```

but I think the plain build is better so used that instead.