### PR TITLE
Add ban.spellright

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -155,6 +155,10 @@
       "repository": "https://github.com/Bajdzis/vscode-database"
     },
     {
+      "id": "ban.spellright",
+      "repository": "https://github.com/bartosz-antosik/vscode-spellright"
+    },
+    {
       "id": "batisteo.vscode-django",
       "repository": "https://github.com/vscode-django/vscode-django"
     },


### PR DESCRIPTION
MIT licence; author has not responded in adding the extension since Oct 5th 2020