### PR TITLE
add Tyriar.sort-lines extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1482,6 +1482,13 @@
       "version": "0.2.0"
     },
     {
+      "id": "Tyriar.sort-lines",
+      "repository": "https://github.com/Tyriar/vscode-sort-lines",
+      "version": "1.9.0",
+      "prepublish": "npx vsce package",
+      "extensionFile": "sort-lines-1.9.0.vsix"
+    },
+    {
       "id": "twxs.cmake",
       "repository": "https://github.com/twxs/vs.language.cmake"
     },

--- a/extensions.json
+++ b/extensions.json
@@ -1484,9 +1484,7 @@
     {
       "id": "Tyriar.sort-lines",
       "repository": "https://github.com/Tyriar/vscode-sort-lines",
-      "version": "1.9.0",
-      "prepublish": "npx vsce package",
-      "extensionFile": "sort-lines-1.9.0.vsix"
+      "prepublish": "yarn compile"
     },
     {
       "id": "twxs.cmake",


### PR DESCRIPTION
I created this PR because creator of this extension [doesn't want](https://github.com/Tyriar/vscode-sort-lines/issues/92) to manage publishing to OVSX himself.