### PR TITLE
Add/update GitHub namespace extensions

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -578,9 +578,14 @@
       "repository": "https://github.com/giscafer/leek-fund"
     },
     {
+      "id": "GitHub.github-vscode-theme",
+      "repository": "https://github.com/primer/github-vscode-theme",
+      "prepublish": "npm run build"
+    },
+    {
       "id": "GitHub.vscode-pull-request-github",
-      "download": "https://github.com/microsoft/vscode-pull-request-github/releases/download/0.25.1/vscode-pull-request-github-0.25.1.vsix",
-      "version": "0.25.1"
+      "download": "https://github.com/microsoft/vscode-pull-request-github/releases/download/0.26.0/vscode-pull-request-github-0.26.0.vsix",
+      "version": "0.26.0"
     },
     {
       "id": "golang.go",

--- a/extensions.json
+++ b/extensions.json
@@ -580,6 +580,8 @@
     {
       "id": "GitHub.github-vscode-theme",
       "repository": "https://github.com/primer/github-vscode-theme",
+      "version": "4.1.1",
+      "checkout": "v4.1.1",
       "prepublish": "npm run build"
     },
     {


### PR DESCRIPTION
One of the GitHub extensions (vscode pull request) has received an extension update.

The other was removed from the publish file for some reason and has not been updated - a user had filed an issue about this in the extension's repo (primer/github-vscode-theme#171) and the maintainer has previously filed a PR to publish this extension (PR #63)