### PR TITLE
Swellaby.vscode-rust-test-adapter: Add prepublish step to build js files

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1476,7 +1476,8 @@
     },
     {
       "id": "Swellaby.vscode-rust-test-adapter",
-      "repository": "https://github.com/swellaby/vscode-rust-test-adapter"
+      "repository": "https://github.com/swellaby/vscode-rust-test-adapter",
+      "prepublish": "npm update vscode && npm install && npm run build"
     },
     {
       "id": "tchayen.markdown-links",


### PR DESCRIPTION
This extension hasn't had a version bump in a while, and it's not clear when the next version will be released.  Is it possible to update the contents of this extension on Open VSX with this change?  Otherwise the extension as is does not function (it's missing all of its javascript application code).