### PR TITLE
Add vscode-js-profile-{table, flame} extensions

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1203,6 +1203,13 @@
       "repository": "https://github.com/Microsoft/vscode-sublime-keybindings"
     },
     {
+      "id": "ms-vscode.vscode-js-profile-flame",
+      "repository": "https://github.com/microsoft/vscode-js-profile-visualizer",
+      "version": "0.0.21",
+      "checkout": "v0.0.21",
+      "location": "packages/vscode-js-profile-flame"
+    },
+    {
       "id": "ms-vscode.vscode-js-profile-table",
       "repository": "https://github.com/microsoft/vscode-js-profile-visualizer",
       "version": "0.0.21",

--- a/extensions.json
+++ b/extensions.json
@@ -1207,6 +1207,7 @@
       "repository": "https://github.com/microsoft/vscode-js-profile-visualizer",
       "version": "0.0.21",
       "checkout": "v0.0.21",
+      "prepublish": "npm run compile",
       "location": "packages/vscode-js-profile-flame"
     },
     {
@@ -1214,6 +1215,7 @@
       "repository": "https://github.com/microsoft/vscode-js-profile-visualizer",
       "version": "0.0.21",
       "checkout": "v0.0.21",
+      "prepublish": "npm run compile",
       "location": "packages/vscode-js-profile-table"
     },
     {

--- a/extensions.json
+++ b/extensions.json
@@ -1203,6 +1203,13 @@
       "repository": "https://github.com/Microsoft/vscode-sublime-keybindings"
     },
     {
+      "id": "ms-vscode.vscode-js-profile-table",
+      "repository": "https://github.com/microsoft/vscode-js-profile-visualizer",
+      "version": "0.0.21",
+      "checkout": "v0.0.21",
+      "location": "packages/vscode-js-profile-table"
+    },
+    {
       "id": "mtxr.sqltools",
       "repository": "https://github.com/mtxr/vscode-sqltools",
       "version": "0.23.0",


### PR DESCRIPTION
Those two extensions are from [vscode-js-profile-visualizer repo](https://github.com/microsoft/vscode-js-profile-visualizer) under MIT license.
- ms-vscode.vscode-js-profile-table is also an extension built-in VSCodium and Code - OSS like node-debug
- ms-vscode.vscode-js-profile-flame is the other released extension from this repo

Edit: the repo don't directly release vsix files