### PR TITLE
Add Back & Forth to `extensions.json`

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1229,6 +1229,10 @@
       "repository": "https://github.com/neild3r/vscode-php-docblocker"
     },
     {
+      "id": "nick-rudenko.back-n-forth",
+      "repository": "https://github.com/nikita-rudenko/back-n-forth"
+    },
+    {
       "id": "Nightrains.robloxlsp",
       "repository": "https://github.com/NightrainsRbx/RobloxLsp"
     },


### PR DESCRIPTION
This plugin is MIT licensed and was formerly published to the repository, but the publisher [hasn't signed the publishers' agreement](https://github.com/nikita-rudenko/back-n-forth/issues/14) since that requirement came into force.