### PR TITLE
Add x86 assembly plugin

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1,6 +1,10 @@
 {
   "extensions": [
     {
+      "id": "13xforever.language-x86-64-assembly",
+      "repository": "https://github.com/13xforever/x86_64-assembly-vscode"
+    },
+    {
       "id": "aaron-bond.better-comments",
       "repository": "https://github.com/aaron-bond/better-comments"
     },


### PR DESCRIPTION
The plugin is [MIT licensed](https://github.com/13xforever/x86_64-assembly-vscode/blob/master/LICENSE.txt), and the author has expressed [no interest](https://github.com/13xforever/x86-assembly-textmate-bundle/issues/19) in going through the Open VSX publishing process, so it seems like this is the best way to make it available.