### PR TITLE
Remove the git-client-ibmi extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -649,12 +649,6 @@
       "checkout": "0.5.8"
     },
     {
-      "id": "halcyontechltd.git-client-ibmi",
-      "repository": "https://github.com/halcyon-tech/git-client-ibmi",
-      "version": "0.0.4",
-      "checkout": "0.0.4"
-    },
-    {
       "id": "HansUXdev.bootstrap5-snippets",
       "repository": "https://github.com/HansUXdev/B5-Snippets",
       "prepublish": "npm run concat"


### PR DESCRIPTION
The git-client-ibmi extension has a misnamed license file which
causes the upgrade-extensions workflow to fail (see
https://github.com/open-vsx/publish-extensions/runs/2981924283?check_suite_focus=true).

An upstream PR has been raised to correct the filename (see
https://github.com/halcyon-tech/git-client-ibmi/pull/1) but
until that has been merged then upgrade-extensions will never
succeed. So, temporarily remove the extension.