### PR TITLE
extensions: add yzhane.markdown-pdf

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1716,6 +1716,11 @@
       "repository": "https://github.com/yifu/highlight-trailing-whitespaces"
     },
     {
+      "id": "yzane.markdown-pdf",
+      "download": "https://github.com/yzane/vscode-markdown-pdf/releases/download/1.4.4/markdown-pdf-1.4.4.vsix",
+      "version": "1.4.4"
+    },
+    {
       "id": "yzhang.markdown-all-in-one",
       "repository": "https://github.com/yzhang-gh/vscode-markdown"
     },


### PR DESCRIPTION
The [issue](https://github.com/yzane/vscode-markdown-pdf/issues/211) has been open for months now. I've been having a hard time trying to get CLI-based markdown-to-pdf converters to work, and I don't want to send my particular markdown files to someone's server. This would be awesome to have available in Open VSX. 