### PR TITLE
remove explicit version for ms-vscode.hexeditor

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1254,8 +1254,6 @@
     {
       "id": "ms-vscode.hexeditor",
       "repository": "https://github.com/microsoft/vscode-hexeditor",
-      "version": "1.3.0",
-      "checkout": "1.3.0"
     },
     {
       "id": "ms-vscode.js-debug",


### PR DESCRIPTION
... as this is very outdated (the extension does not do release-tagging).

In the hope to get it updated from 1.3.0 to 1.8.2.