### PR TITLE
Fix rubyide/vscode-ruby settings

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1515,8 +1515,10 @@
     },
     {
       "id": "rebornix.ruby",
-      "download": "https://github.com/rubyide/vscode-ruby/releases/download/v0.28.0/ruby-0.28.0.vsix",
-      "version": "0.28.0"
+      "repository": "https://github.com/rubyide/vscode-ruby",
+      "version": "0.28.1",
+      "checkout": "v0.28.1",
+      "location": "packages/vscode-ruby-client"
     },
     {
       "id": "reduckted.vscode-gitweblinks",
@@ -1886,8 +1888,8 @@
     {
       "id": "wingrunr21.vscode-ruby",
       "repository": "https://github.com/rubyide/vscode-ruby",
-      "version": "0.28.0",
-      "checkout": "v0.28.0",
+      "version": "0.28.1",
+      "checkout": "v0.28.1",
       "location": "packages/vscode-ruby"
     },
     {


### PR DESCRIPTION
Currently wingrunr21.vscode-ruby is failed to build

https://github.com/open-vsx/publish-extensions/runs/3511558538?check_suite_focus=true

```
[FAIL] Could not process extension: {
  "id": "wingrunr21.vscode-ruby",
  "repository": "https://github.com/rubyide/vscode-ruby",
  "version": "0.28.0",
  "checkout": "v0.28.0",
  "location": "packages/vscode-ruby"
}
Error: Command failed: yarn install
error Couldn't find package "language-server-ruby@^0.27.0" required by "ruby@0.28.0" on the "npm" registry.

    at ChildProcess.exithandler (child_process.js:308:12)
    at ChildProcess.emit (events.js:314:20)
    at maybeClose (internal/child_process.js:1022:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:287:5) {
  killed: false,
  code: 1,
  signal: null,
  cmd: 'yarn install'
}
```

In addition, rebornix.ruby has a new release but it doesn't have vsix file on release page.

https://github.com/rubyide/vscode-ruby/releases/tag/v0.28.1

They're in the same repository so I guess both of them should be published and keeps the same version.
