### PR TITLE
Remove deprecated web flag when publishing an extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1353,8 +1353,7 @@
     },
     {
       "id": "ms-vscode.vscode-smoketest-check",
-      "repository": "https://github.com/microsoft/vscode-smoketest-check",
-      "web": true
+      "repository": "https://github.com/microsoft/vscode-smoketest-check"
     },
     {
       "id": "msjsdiag.debugger-for-edge",
@@ -1844,8 +1843,7 @@
     {
       "id": "vscodevim.vim",
       "download": "https://github.com/VSCodeVim/Vim/releases/download/v1.21.6/vim-1.21.6.vsix",
-      "version": "1.21.6",
-      "web": true
+      "version": "1.21.6"
     },
     {
       "id": "vshaxe.haxe-checkstyle",
@@ -1872,8 +1870,7 @@
     },
     {
       "id": "vsls-contrib.codetour",
-      "repository": "https://github.com/vsls-contrib/codetour",
-      "web": true
+      "repository": "https://github.com/vsls-contrib/codetour"
     },
     {
       "id": "wayou.vscode-todo-highlight",

--- a/publish-extension.js
+++ b/publish-extension.js
@@ -28,7 +28,6 @@ const exec = require('./lib/exec');
      *        prepublish?: string,
      *        download?: string,
      *        extensionFile?: string
-     *        web?: boolean
      *    }}
      */
     const extension = JSON.parse(process.argv[2]);
@@ -100,9 +99,7 @@ const exec = require('./lib/exec');
             // Publish the extension.
             /** @type {import('ovsx').PublishOptions} */
             const options = { extensionFile: '/tmp/download/extension.vsix' };
-            options.web = extension.web;
             await ovsx.publish(options);
-
         } else {
             // Clone and set up the repository.
             await exec(`git clone --recurse-submodules ${extension.repository} /tmp/repository`);
@@ -131,9 +128,7 @@ const exec = require('./lib/exec');
             if (yarn) {
                 options.yarn = true;
             }
-            options.web = extension.web;
             await ovsx.publish(options);
-
         }
         console.log(`[OK] Successfully published ${id} to Open VSX!`)
     } catch (error) {


### PR DESCRIPTION
Merge this after https://github.com/eclipse/openvsx/pull/326 is deployed into production
cc @akosyakov 