### PR TITLE
add gitdoc extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1867,6 +1867,10 @@
       "repository": "https://github.com/vsls-contrib/codetour"
     },
     {
+      "id": "vsls-contrib.gitdoc",
+      "repository": "https://github.com/lostintangent/gitdoc"
+    },
+    {
       "id": "wayou.vscode-todo-highlight",
       "repository": "https://github.com/wayou/vscode-todo-highlight"
     },


### PR DESCRIPTION
Original author stated he [doesn't have the bandwidth](https://github.com/lostintangent/gitdoc/issues/15) to submit directly.

Extension is [MIT licensed](https://github.com/lostintangent/gitdoc/blob/master/LICENSE.txt).