### PR TITLE
Fix rebornix.ruby build

### DIFF
--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -18,6 +18,13 @@ jobs:
     name: node publish-extensions
     runs-on: ubuntu-latest
     steps:
+    # rebornix.ruby 0.28.1 requires emcc 2.0.0
+    - run: |
+        git clone https://github.com/emscripten-core/emsdk /tmp/emsdk
+        cd /tmp/emsdk
+        ./emsdk install 2.0.0
+        ./emsdk activate 2.0.0 --global
+        echo "/tmp/emsdk/upstream/emscripten" >> $GITHUB_PATH
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:


### PR DESCRIPTION
Sorry https://github.com/open-vsx/publish-extensions/pull/429 is not enough.

https://github.com/open-vsx/publish-extensions/actions/runs/1268340846

```
Traceback (most recent call last):
  File "/emsdk_portable/emscripten/tag-1.39.4/emcc.py", line 3704, in <module>
    sys.exit(run(sys.argv))
  File "/emsdk_portable/emscripten/tag-1.39.4/emcc.py", line 2512, in run
    optimizer)
  File "/emsdk_portable/emscripten/tag-1.39.4/emcc.py", line 3022, in do_binaryen
    os.unlink(memfile)
OSError: [Errno 2] No such file or directory: 'tree-sitter-ruby.wasm.mem'
```

I confirmed installing emcc 2.0.0 fixes this build error.

https://github.com/mtsmfm/publish-extensions/actions/runs/1269972868