### PR TITLE
[extensions]: Add Tyriar.windows-terminal (MIT License)

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1156,6 +1156,9 @@
     "repository": "https://github.com/Tyriar/vscode-sort-lines",
     "prepublish": "yarn compile"
   },
+  "Tyriar.windows-terminal": {
+    "repository": "https://github.com/Tyriar/vscode-windows-terminal"
+  },
   "Unity.unity-debug": {
     "repository": "https://github.com/Unity-Technologies/vscode-unity-debug"
   },


### PR DESCRIPTION
Adds https://github.com/Tyriar/vscode-windows-terminal to OpenVSX.