### PR TITLE
feat: add debug upgrade script

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ Here are all the supported values, including optional ones, to build extensions 
     },
 ```
 
+## How do extensions get updated?
+
+Every week [a job is ran which checks for updated versions][upgrade-extensions-job]. These changes are reviewed manually, and merged by a maintainer. Once merged, these upgrades are [published nightly][publish-extensions-job]. There should be no reason to raise a PR to update an extension. It could be that the extension is failing to update. 
+
+To debug, try running `node upgrade-extensions.js --extension=the-extension-id`, which will try to run the upgrade only for that one extension, providing an error report/reason for why the extension is not updating. 
 
 ## How are Extensions Published?
 
@@ -97,3 +102,6 @@ The [publishing process](https://github.com/open-vsx/publish-extensions/blob/d2d
 6. [`ovsx publish`](https://github.com/open-vsx/publish-extensions/blob/d2df425a84093023f4ee164592f2491c32166297/publish-extensions.js#L86) (with `--yarn` if a `yarn.lock` file was detected earlier)
 
 See all `ovsx` CLI options [here](https://github.com/eclipse/openvsx/blob/master/cli/README.md).
+
+[upgrade-extensions-job]: https://github.com/open-vsx/publish-extensions/blob/master/.github/workflows/upgrade-extensions.yml
+[publish-extensions-job]: https://github.com/open-vsx/publish-extensions/blob/master/.github/workflows/publish-extensions.yml

--- a/upgrade-extensions.js
+++ b/upgrade-extensions.js
@@ -11,6 +11,7 @@
 // @ts-check
 const fs = require('fs');
 const util = require('util');
+const minimist = require('minimist');
 const exec = require('./lib/exec');
 const gitHubScraper = require('./lib/github-scraper');
 const readFile = util.promisify(fs.readFile);
@@ -54,8 +55,9 @@ const dontUpgrade = [
    * }}
    */
   const { extensions } = JSON.parse(await readFile('./extensions.json', 'utf-8'));
-  const extensionRepositoriesToUpgrade = extensions.filter(e => !dontUpgrade.includes(e.id) && !!e.version && !e.download);
-  const extensionDownloadsToUpgrade = extensions.filter(e => !dontUpgrade.includes(e.id) && /https:\/\/github.com\/.*\/releases\/download\//.test(e.download));
+  const cliCommandFlags = minimist(process.argv.slice(2));
+  const extensionRepositoriesToUpgrade = extensions.filter(e => (!cliCommandFlags.extension || e.id.includes(cliCommandFlags.extension)) && !dontUpgrade.includes(e.id) && !!e.version && !e.download);
+  const extensionDownloadsToUpgrade = extensions.filter(e => (!cliCommandFlags.extension || e.id.includes(cliCommandFlags.extension)) && !dontUpgrade.includes(e.id) && /https:\/\/github.com\/.*\/releases\/download\//.test(e.download));
   const extensionsToNotUpgrade = extensions.filter(e => !extensionRepositoriesToUpgrade.concat(extensionDownloadsToUpgrade).map(e => e.id).includes(e.id));
 
   fs.renameSync('./extensions.json', './extensions.json.old');


### PR DESCRIPTION
To help with debugging PR's where contributors are bumping versions, I'm adding a filter to the upgrade script, to quickly debug why an extension might not be updating automatically, without: 

* Manipulate `extensions.json`
* Or run the full upgrade script (lots of noise) and takes some time

Also added a note to the README for this. 

To test the changes:

Run with filter:
```bash
git checkout extensions.json && node upgrade-extensions.js --extension=barrettotte.ibmi-languages # => Should run only one upgrade
```

Run without filter: 
```bash
git checkout extensions.json && node upgrade-extensions.js # => Should run all upgrades
```