### PR TITLE
fix: ensure we do not publish higher versions than specified in extensions.json

### DIFF
--- a/publish-extension.js
+++ b/publish-extension.js
@@ -128,6 +128,14 @@ const exec = require('./lib/exec');
             if (yarn) {
                 options.yarn = true;
             }
+
+            const { version }  = require('/tmp/repository/package.json');
+
+            // If the version in the branch is not the same as given in the extensions.json
+            if (semver.neq(version, extension.version)) {
+                throw new Error(`The version: ${version} found in the downloaded package.json is not the same as found in ${extension.version}`);
+            }
+
             await ovsx.publish(options);
         }
         console.log(`[OK] Successfully published ${id} to Open VSX!`)


### PR DESCRIPTION
A PR was raised (https://github.com/open-vsx/publish-extensions/pull/468) to bump a version of an extension (`barrettotte.ibmi-languages` from `0.6.0` to `0.6.2`). Despite having a lower version currently in the extensions.json (`0.6.0`) the higher version, `0.6.2` was already published (...how?). 

This situation shouldn't be possible, as a given `extensions.json` `version` property _should match exactly the version we are attempting to build/publish_ otherwise, we risk publishing potentially later/higher versions than we expect, making the `extensions.json` file misleading, and causing users to raise additional PR's (such as the one in question https://github.com/open-vsx/publish-extensions/pull/468).

To add more confusion, following the situation where a version is bumped higher than is expected, this causes [subsequent publish attempts to fail](https://github.com/open-vsx/publish-extensions/runs/3992319373?check_suite_focus=true#step:8:1393). The situation also does not resolve itself on the next upgrade as the upgrade [errors if the published version exceeds the requested version](https://github.com/open-vsx/publish-extensions/blob/master/add-extension.js#L190) and refuses/doesn't to bump the version. 

You can see from [the publishing logs](https://github.com/open-vsx/publish-extensions/runs/3982247033?check_suite_focus=true#step:8:1378) that the requested version was `0.6.0`, but the published version was `v0.6.2`. Whereas expected behaviour here should have been an error, which would should then be resolved in the next upgrade/publish cycle. 

```bash
Processing extension: {
  "id": "barrettotte.ibmi-languages",
  "repository": "https://github.com/barrettotte/vscode-ibmi-languages",
  "version": "0.6.0"
}
Checking Open VSX version of barrettotte.ibmi-languages
Found version: 0.5.5
Attempting to publish barrettotte.ibmi-languages to Open VSX
Creating Open VSX namespace failed -- assuming that it already exists
Error: Namespace already exists: barrettotte
    at IncomingMessage.<anonymous> (/home/runner/work/publish-extensions/publish-extensions/node_modules/ovsx/lib/registry.js:173:40)
    at IncomingMessage.emit (events.js:412:35)
    at endReadableNT (internal/streams/readable.js:1334:12)
    at processTicksAndRejections (internal/process/task_queues.js:82:21)
Running: git clone --recurse-submodules https://github.com/barrettotte/vscode-ibmi-languages /tmp/repository
Cloning into '/tmp/repository'...
Running: npm install
added 4 packages from 8 contributors and audited 4 packages in 0.275s
found 0 vulnerabilities

 DONE  Packaged: /tmp/tmp-4603-FO5uS32VfYFc-.vsix (36 files, 789.18KB)

🚀  Published barrettotte.ibmi-languages v0.6.2
[OK] Successfully published barrettotte.ibmi-languages to Open VSX!
Running: rm -rf /tmp/repository /tmp/download
```

This situation occurs because we are currently only checking: 

* If the [version is already published](https://github.com/open-vsx/publish-extensions/blob/master/publish-extension.js#L62) (in this case it was not)
* If the [Open VSX published version is already further ahead](https://github.com/open-vsx/publish-extensions/blob/master/publish-extension.js#L59) (in this case it was not)

However, we're not currently checking: 

* If the specified version in `package.json` exceeds the one found in `extensions.json`

The suggested fix is to error if the requested version from the `extensions.json` is not equal to the version that is being attempted to be published. 

**Note:** I am not sure how to test this fix without running a publish cycle 😁 

Closes #475