### PR TITLE
use VSIX download for Rust Test Adapter

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1713,7 +1713,8 @@
     },
     {
       "id": "Swellaby.vscode-rust-test-adapter",
-      "repository": "https://github.com/swellaby/vscode-rust-test-adapter"
+      "download": "https://github.com/swellaby/vscode-rust-test-adapter/releases/download/v0.11.1/vscode-rust-test-adapter-0.11.1.vsix",
+      "version": "0.11.1"
     },
     {
       "id": "tchayen.markdown-links",


### PR DESCRIPTION
The existing package and publish process has been broken for a while, and should finally be resolved with this.

Refs https://github.com/open-vsx/publish-extensions/pull/352 and https://github.com/EclipseFdn/open-vsx.org/issues/649