### PR TITLE
Remove extension, now published by author

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -168,11 +168,6 @@
       "repository": "https://github.com/bartosz-antosik/vscode-spellright"
     },
     {
-      "id": "barrettotte.ibmi-languages",
-      "repository": "https://github.com/barrettotte/vscode-ibmi-languages",
-      "version": "0.6.2"
-    },
-    {
       "id": "batisteo.vscode-django",
       "repository": "https://github.com/vscode-django/vscode-django"
     },


### PR DESCRIPTION
The extension is now being published by the author directly, so no need anymore for the extension being published here.

This will also fix the breakdown of the extension upgrade action, which has a problem with the versions of this extension.