### PR TITLE
docs: update README with reasons for publishing extensions at source

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,13 @@ A CI script for publishing open-source VS Code extensions to [open-vsx.org](http
 
 ## When to Add an Extension?
 
-One goal of Open VSX is to have extension maintainers publish their extensions [according to the documentation](https://github.com/eclipse/openvsx/wiki/Publishing-Extensions). However, you may be missing specific extensions that have not been published by their maintainers: either they are not willing to do it, or they haven't found time to do it, or simply they haven't heard about Open VSX yet. Though the preferred solution for such a situation is to convince the maintainers to start publishing themselves, you can add the extensions here to have them published by our CI workflow.
+A goal of Open VSX is to have extension maintainers publish their extensions [according to the documentation](https://github.com/eclipse/openvsx/wiki/Publishing-Extensions). The first step we recommend is to open an issue with the extension owner. If the extension owner is unresponsive for some time, this repo (publish-extensions) can be used **as a temporary workaround** to esure the extension is published to Open VSX. 
+
+In the long-run it is better for extension owners to publish their own plugins because: 
+
+1. Any future issues (features/bugs) with any published extensions in Open VSX will be directed to their original repo/source-control, and not confused with this repo `publish-extensions`.
+1. Extensions published by official authors are shown within the Open VSX marketplace as such. Whereas extensions published via publish-extensions display a warning that the publisher (this repository) is not the official author.
+1. Extension owners who publish their own extensions get greater flexibility on the publishing/release process, therefore ensure more accuracy/stability. For instance, in some cases publish-extensions has build steps within this repository, which can cause some uploaded plugin versions to break (e.g. if a plugin build step changes). 
 
 ⚠️ We accept only extensions with [OSI-approved open source licenses](https://opensource.org/licenses) here. If you want to have an extension with a proprietary or non-approved license, please ask its maintainers to publish it.
 


### PR DESCRIPTION
This change updates the README to try to explain some of the reasons why publishing at a source repo is better than within `publish-extensions`. Any further reasoning, or wording updates are very welcome! 