### PR TITLE
Cleanly install dependencies

### DIFF
--- a/publish-extension.js
+++ b/publish-extension.js
@@ -109,7 +109,7 @@ const exec = require('./lib/exec');
             let yarn = await new Promise(resolve => {
                 fs.access(path.join('/tmp/repository', 'yarn.lock'), error => resolve(!error));
             });
-            await exec(`${yarn ? 'yarn' : 'npm'} install`, { cwd: '/tmp/repository' });
+            await exec(yarn ? 'yarn install --frozen-lockfile --ignore-engines' : 'npm ci', { cwd: '/tmp/repository' });
             if (extension.prepublish) {
                 await exec(extension.prepublish, { cwd: '/tmp/repository' })
             }


### PR DESCRIPTION
Don't update the lockfile (`package-lock.json` or `yarn.lock`) when installing extension dependencies.

## How to test
The easiest way to test this is to run all the commands done by https://github.com/open-vsx/publish-extensions/blob/master/publish-extension.js manually.