### PR TITLE
[extension]: add damc.textpad-color-theme

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -201,6 +201,9 @@
   "ctf0.macros": {
     "repository": "https://github.com/ctf0/macros"
   },
+  "damc.textpad-color-theme": {
+    "repository": "https://github.com/damc-code/themes"
+  },
   "damonsk.vscode-wardley-maps": {
     "repository": "https://github.com/damonsk/vscode-wardley-maps"
   },


### PR DESCRIPTION
I'd like to add the `damc.textpad-color-theme` theme (extension) to OpenVSX. \
**License:** [MIT](https://github.com/damc-code/themes/blob/master/LICENSE.txt).

Unfortunately, it does not seem to be maintained anymore. Since this is a theme, that's not really a problem.

I've [created a ticket](https://github.com/damc-code/themes/issues/1) but didn't get a response, yet.