### PR TITLE
Allow for other git hosts other than GitHub

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -973,7 +973,7 @@
     "repository": "https://github.com/pj3677/vscode-protobuf"
   },
   "pflannery.vscode-versionlens": {
-    "repository": "https://gitlab.com/versionlens/vscode-versionlens/uploads/f27e3b7101dbf62dcc54884374870095/vscode-versionlens-1.0.9.vsix"
+    "repository": "https://gitlab.com/versionlens/vscode-versionlens/"
   },
   "ph-hawkins.arc-plus": {
     "repository": "https://github.com/phil-harmoniq/arc-plus"

--- a/lib/resolveExtension.js
+++ b/lib/resolveExtension.js
@@ -20,17 +20,13 @@ const octokit = new Octokit({ auth: token });
  * @returns {Promise<import('../types').ResolvedExtension | undefined>}
  */
 exports.resolveExtension = async function ({ id, repository, location }, ms) {
-  // TODO(ak) support gitlab
   const repositoryUrl = new URL(repository);
-  if (repositoryUrl.hostname !== 'github.com') {
-    return undefined;
-  }
   const [owner, repo] = repositoryUrl.pathname.slice(1).split("/");
 
   //#region check latest release assets
   /** @type {string | undefined} */
   let releaseTag;
-  if (ms) {
+  if (ms && repositoryUrl.hostname === 'github.com') {
     try {
       const releaseReponse = await octokit.rest.repos.getLatestRelease({ owner, repo });
       const release = releaseReponse.data;


### PR DESCRIPTION
The only change here is that if the host of the `repository` property isn't GitHub.com, the script does all the logic locally, no API calling.

## How to test

Execute the following:
```
EXTENSIONS=pflannery.vscode-versionlens SKIP_PUBLISH=true FORCE=true GITHUB_TOKEN=blabla node publish-extensions.js
```
(`GITHUB_TOKEN` can really be `blabla`, we don't need to access the API, but we need to provide it.)