### PR TITLE
Check whether extension has an OSI approved license

### DIFF
--- a/lib/checkLicense.js
+++ b/lib/checkLicense.js
@@ -1,5 +1,14 @@
-// @ts-check
+/********************************************************************************
+ * Copyright (c) 2022 TypeFox and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
 
+// @ts-check
 const checkLicense = require("osi-license-checker");
 const fs = require('fs');
 const octokit = require('octokit');

--- a/lib/checkLicense.js
+++ b/lib/checkLicense.js
@@ -1,0 +1,47 @@
+// @ts-check
+
+const checkLicense = require("osi-license-checker");
+const fs = require('fs');
+const octokit = require('octokit');
+
+/**
+ * Check if the extension has an OSI-approved open-source license
+ * @param {URL} url
+ * @param {string} owner
+ * @param {string} repo
+ * @param {octokit.Octokit} octokit a preauthenthicated octokit client
+ * @param {string} packagePath
+ */
+exports.checkLicense = async function(url, owner, repo, octokit, packagePath) {
+  try {
+    const manifest = JSON.parse(
+      await fs.promises.readFile(packagePath, "utf-8")
+    );
+    const license = manifest.license;
+    if (!license) {
+      if (!checkLicense.checkShorthand(license)) {
+        console.error(`Not an OSS license: ${license}`);
+        return false;
+      }
+
+      if (url.hostname !== "github.com") {
+        console.error("Can' check license on non-github repositories ");
+        return false;
+      }
+
+      const ghLicenseResponse = (
+        await octokit.rest.licenses.getForRepo({ owner, repo })
+      ).data.license;
+      if (!checkLicense.checkShorthand(ghLicenseResponse.spdx_id)) {
+        console.error(
+          `Not an OSS license: ${ghLicenseResponse.name} (${ghLicenseResponse.spdx_id})`
+        );
+        return false;
+      }
+      return true;
+    }
+  } catch (e) {
+    console.error("Can't get license", e);
+    return false;
+  }
+}

--- a/lib/resolveExtension.js
+++ b/lib/resolveExtension.js
@@ -4,9 +4,9 @@ const fs = require('fs');
 const path = require('path');
 const Octokit = require('octokit').Octokit;
 const readVSIXPackage = require('vsce/out/zip').readVSIXPackage;
-const checkLicense = require('osi-license-checker');
 const download = require('download');
 const exec = require('./exec');
+const { checkLicense } = require('./checkLicense');
 
 const token = process.env.GITHUB_TOKEN;
 if (!token) {
@@ -54,34 +54,6 @@ exports.resolveExtension = async function ({ id, repository, location }, ms) {
   await exec(`git clone --filter=blob:none --recurse-submodules ${repository} ${repoPath}`, { quiet: true });
 
   const packagePath = [repoPath, location, 'package.json'].filter(p => !!p).join('/');
-
-  //#region Check if the extension has an OSI-approved open-source license
-  try {
-    const manifest = JSON.parse(await fs.promises.readFile(packagePath, 'utf-8'));
-    const license = manifest.license;
-    if (!license) {
-
-      if (!checkLicense.checkShorthand(license)) {
-        console.error(`Not an OSS license: ${license}`);
-        return undefined;
-      }
-
-      if (repositoryUrl.hostname !== 'github.com') {
-        console.error('Can\' check license on non-github repositories ')
-        return undefined;
-      }
-
-      const ghLicenseResponse = (await octokit.rest.licenses.getForRepo({ owner, repo })).data.license;
-      if (!checkLicense.checkShorthand(ghLicenseResponse.spdx_id)) {
-        console.error(`Not an OSS license: ${ghLicenseResponse.name} (${ghLicenseResponse.spdx_id})`);
-        return undefined;
-      }
-    }
-  } catch {
-    console.log('Can\'t get license');
-    return undefined;
-  }
-  //#endregion
 
   /**
    * @param {string} ref

--- a/lib/resolveExtension.js
+++ b/lib/resolveExtension.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const Octokit = require('octokit').Octokit;
 const readVSIXPackage = require('vsce/out/zip').readVSIXPackage;
-const osiLicenses = require('osi-licenses');
+const checkLicense = require('osi-license-checker');
 const download = require('download');
 const exec = require('./exec');
 
@@ -59,17 +59,17 @@ exports.resolveExtension = async function ({ id, repository, location }, ms) {
   try {
     const manifest = JSON.parse(await fs.promises.readFile(packagePath, 'utf-8'));
     const license = manifest.license;
-    if (!(license && Object.keys(osiLicenses).includes(license))) {
+    if (!(license && checkLicense.checkShorthand(license))) {
       if (repositoryUrl.hostname !== 'github.com') return undefined;
 
       const ghLicenseResponse = (await octokit.rest.licenses.getForRepo({ owner, repo })).data.license;
-      if (!Object.keys(osiLicenses).includes(ghLicenseResponse.spdx_id)) {
+      if (!checkLicense.checkShorthand(ghLicenseResponse.spdx_id)) {
         console.log(`Not an OSS license: ${ghLicenseResponse.name} (${ghLicenseResponse.spdx_id})`);
         return undefined;
       }
     }
   } catch {
-    console.log('Can\'t process license');
+    console.log('Can\'t get license');
     return undefined;
   }
   //#endregion

--- a/lib/resolveExtension.js
+++ b/lib/resolveExtension.js
@@ -59,12 +59,21 @@ exports.resolveExtension = async function ({ id, repository, location }, ms) {
   try {
     const manifest = JSON.parse(await fs.promises.readFile(packagePath, 'utf-8'));
     const license = manifest.license;
-    if (!(license && checkLicense.checkShorthand(license))) {
-      if (repositoryUrl.hostname !== 'github.com') return undefined;
+    if (!license) {
+
+      if (!checkLicense.checkShorthand(license)) {
+        console.error(`Not an OSS license: ${license}`);
+        return undefined;
+      }
+
+      if (repositoryUrl.hostname !== 'github.com') {
+        console.error('Can\' check license on non-github repositories ')
+        return undefined;
+      }
 
       const ghLicenseResponse = (await octokit.rest.licenses.getForRepo({ owner, repo })).data.license;
       if (!checkLicense.checkShorthand(ghLicenseResponse.spdx_id)) {
-        console.log(`Not an OSS license: ${ghLicenseResponse.name} (${ghLicenseResponse.spdx_id})`);
+        console.error(`Not an OSS license: ${ghLicenseResponse.name} (${ghLicenseResponse.spdx_id})`);
         return undefined;
       }
     }

--- a/lib/resolveExtension.js
+++ b/lib/resolveExtension.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const path = require('path');
 const Octokit = require('octokit').Octokit;
 const readVSIXPackage = require('vsce/out/zip').readVSIXPackage;
+const osiLicenses = require('osi-licenses');
 const download = require('download');
 const exec = require('./exec');
 
@@ -53,6 +54,26 @@ exports.resolveExtension = async function ({ id, repository, location }, ms) {
   await exec(`git clone --filter=blob:none --recurse-submodules ${repository} ${repoPath}`, { quiet: true });
 
   const packagePath = [repoPath, location, 'package.json'].filter(p => !!p).join('/');
+
+  //#region Check if the extension has an OSI-approved open-source license
+  try {
+    const manifest = JSON.parse(await fs.promises.readFile(packagePath, 'utf-8'));
+    const license = manifest.license;
+    if (!(license && Object.keys(osiLicenses).includes(license))) {
+      if (repositoryUrl.hostname !== 'github.com') return undefined;
+
+      const ghLicenseResponse = (await octokit.rest.licenses.getForRepo({ owner, repo })).data.license;
+      if (!Object.keys(osiLicenses).includes(ghLicenseResponse.spdx_id)) {
+        console.log(`Not an OSS license: ${ghLicenseResponse.name} (${ghLicenseResponse.spdx_id})`);
+        return undefined;
+      }
+    }
+  } catch {
+    console.log('Can\'t process license');
+    return undefined;
+  }
+  //#endregion
+
   /**
    * @param {string} ref 
    * @returns {Promise<string | undefined>}

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "download": "^8.0.0",
     "minimist": "^1.2.5",
     "octokit": "^1.7.0",
-    "osi-license-checker": "^1.3.0",
+    "osi-license-checker": "latest",
     "ovsx": "latest",
     "semver": "^7.1.3",
     "vsce": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "download": "^8.0.0",
     "minimist": "^1.2.5",
     "octokit": "^1.7.0",
-    "osi-licenses": "^0.1.1",
+    "osi-license-checker": "^1.3.0",
     "ovsx": "latest",
     "semver": "^7.1.3",
     "vsce": "^2.3.0"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "download": "^8.0.0",
     "minimist": "^1.2.5",
     "octokit": "^1.7.0",
+    "osi-licenses": "^0.1.1",
     "ovsx": "latest",
     "semver": "^7.1.3",
     "vsce": "^2.3.0"


### PR DESCRIPTION
Fixes #510

## How to test
1. Add the following to `extensions.json`
```json
  "filiptronicek.unlicensed": {
    "repository": "https://github.com/filiptronicek/test-unlicensed-repo"
  },
```
2. Execute this command and watch the terminal output (also add your own `GITHUB_TOKEN`, so that the script can request the GitHub API for the license)
```
GITHUB_TOKEN=xxx EXTENSIONS=filiptronicek.unlicensed node publish-extensions
```

## ToDo
- [ ] Make sure licenses are checked in every case, including fetching from GitHub releases
	- Using the GitHub API to check the license should be a last resort, because it is not possible to query a license for a specific time 
