### PR TITLE
Reintroduce `vscjava.vscode-maven`

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1193,6 +1193,9 @@
   "vscjava.vscode-java-test": {
     "repository": "https://github.com/microsoft/vscode-java-test"
   },
+  "vscjava.vscode-maven": {
+    "repository": "https://github.com/microsoft/vscode-maven"
+  },
   "vscjava.vscode-spring-boot-dashboard": {
     "repository": "https://github.com/Microsoft/vscode-spring-boot-dashboard"
   },


### PR DESCRIPTION
Fixes #242.

It looks like the extension is building correctly again, so let's add it!
![image](https://user-images.githubusercontent.com/29888641/143617574-195d40ff-23f6-4e46-b637-e56d64af6289.png)
