### PR TITLE
Add extension vemonet.stardog-rdf-grammars

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1162,6 +1162,9 @@
   "Unity.unity-debug": {
     "repository": "https://github.com/Unity-Technologies/vscode-unity-debug"
   },
+  "vemonet.stardog-rdf-grammars": {
+    "repository": "https://github.com/vemonet/stardog-vsc"
+  },
   "vhdlwhiz.vhdl-by-vhdlwhiz": {
     "repository": "https://github.com/jonasjj/awesome-vhdl"
   },

--- a/extensions.json
+++ b/extensions.json
@@ -1163,7 +1163,8 @@
     "repository": "https://github.com/Unity-Technologies/vscode-unity-debug"
   },
   "vemonet.stardog-rdf-grammars": {
-    "repository": "https://github.com/vemonet/stardog-vsc"
+    "repository": "https://github.com/vemonet/stardog-vsc",
+    "location": "stardog-rdf-grammars"
   },
   "vhdlwhiz.vhdl-by-vhdlwhiz": {
     "repository": "https://github.com/jonasjj/awesome-vhdl"


### PR DESCRIPTION
Added the extension `vemonet.stardog-rdf-grammars` (for RDF language highlighting) in the `extensions.json` file

On OpenVSX: https://open-vsx.org/extension/vemonet/stardog-rdf-grammars
The source code: https://github.com/vemonet/stardog-vsc