### PR TITLE
fix build of `johnsoncodehk.volar` & `johnsoncodehk.vscode-typescript-vue-plugin`

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -559,12 +559,12 @@
   },
   "johnsoncodehk.volar": {
     "repository": "https://github.com/johnsoncodehk/volar",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn install && yarn build",
     "location": "extensions/vscode-vue-language-features"
   },
   "johnsoncodehk.vscode-typescript-vue-plugin": {
     "repository": "https://github.com/johnsoncodehk/volar",
-    "prepublish": "yarn compile",
+    "prepublish": "yarn install && yarn build",
     "location": "extensions/vscode-typescript-vue-plugin"
   },
   "jolaleye.horizon-theme-vscode": {

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -25,7 +25,7 @@ module.exports = async (command, options) => {
       cwd: options?.cwd,
       env: {
         ...process.env,
-        // remove on purporse to work around issues in vscode package
+        // remove on purpose to work around issues in vscode package
         GITHUB_TOKEN: undefined
       }
     }, (error, stdout, stderr) => {


### PR DESCRIPTION
Problem:
- command `yarn compile` has to be `yarn build`
- `yarn install` needs to be executed in root folder for the volar repo as it is a yarn / lerna monorepo. 
  `"prepublish": "yarn install && ...",` works as the prepublish command is currently ignoring the `location` option and by that it is executed in the repo root: https://github.com/open-vsx/publish-extensions/blob/377e1d79b7d0a7d307df34b3ae9f30e86b3ccd2c/publish-extension.js#L63 