### PR TITLE
Add `adrieankhisbe.vscode-ndjson`

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -21,6 +21,9 @@
   "adrianhumphreys.silverstripe": {
     "repository": "https://github.com/adrhumphreys/vscode-silverstripe"
   },
+  "adrieankhisbe.vscode-ndjson": {
+    "repository": "https://github.com/AdrieanKhisbe/vscode-ndjson"
+  },
   "ahmadawais.emoji-log-vscode": {
     "repository": "https://github.com/ahmadawais/Emoji-Log-VSCode"
   },


### PR DESCRIPTION
I made an effort to contact the owner in December via e-mail, but I haven't gotten a response. I can't open an issue in the repository in question because it does not have issues enabled. Because this project is under an OSI-approved license (MIT) I think it is suitable for inclusion here. I ran the publish script with this in GitPod and was able to install the extension and it seems to work.