### PR TITLE
Add a workflow for publishing manually

### DIFF
--- a/.github/workflows/publish-once.yml
+++ b/.github/workflows/publish-once.yml
@@ -18,4 +18,4 @@ jobs:
       - name: Download extension file
         run: wget -O extension.vsix ${{ github.event.inputs.publishMS }}
       - name: Publish to OpenVSX
-        run: npx ovsx publish  -p ${{ secrets.OVSX_PAT }}
+        run: npx ovsx publish extension.vsix  -p ${{ secrets.OVSX_PAT }}

--- a/.github/workflows/publish-once.yml
+++ b/.github/workflows/publish-once.yml
@@ -1,0 +1,21 @@
+name: Publish an extensions from a vsix file
+
+on:
+  workflow_dispatch:
+    inputs:
+      extensions:
+        description: "URL of the `.vsix`"
+        required: true
+
+jobs:
+  publish:
+    name: node publish-extensions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+      - name: Download extension file
+        run: wget -O extension.vsix ${{ github.event.inputs.publishMS }}
+      - name: Publish to OpenVSX
+        run: npx ovsx publish  -p ${{ secrets.OVSX_PAT }}


### PR DESCRIPTION
This PR adds a workflow for the maintainers to be able to publish extensions from `.vsix` packages, hopefully making it easier to publish unmaintained extensions so that they can be removed from this repository.