### PR TITLE
Remove SonarSource.sonarlint-vscode

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1094,9 +1094,6 @@
   "sodatea.velocity": {
     "repository": "https://github.com/trilogy-group/vscode-velocity"
   },
-  "SonarSource.sonarlint-vscode": {
-    "repository": "https://github.com/SonarSource/sonarlint-vscode"
-  },
   "steoates.autoimport": {
     "repository": "https://github.com/soates/Auto-Import"
   },


### PR DESCRIPTION
The publication of SonarLint is now handled by a process owned by a dedicated team at SonarSource.

See [related claim of ownership](https://github.com/EclipseFdn/open-vsx.org/issues/765).