### PR TITLE
Use the xml vsix manifest as a primary data source

### DIFF
--- a/publish-extension.js
+++ b/publish-extension.js
@@ -103,7 +103,7 @@ const { createVSIX } = require('vsce');
             }
         }
         // TODO(ak) check license is open-source
-        if (!xmlManifest?.PackageManifest?.Metadata[0]?.License && !(packagePath && await ovsx.isLicenseOk(packagePath, manifest))) {
+        if (!xmlManifest?.PackageManifest?.Metadata[0]?.License?.[0] && !(packagePath && await ovsx.isLicenseOk(packagePath, manifest))) {
             throw new Error(`${extension.id}: license is missing`);
         }
 


### PR DESCRIPTION
This fixes license resolutions for extensions like https://github.com/Microsoft/vscode-java-test, which don't have a `license` field in their manifest (`package.json`), but do as a file in the repository, while offering `vsix` release assets at the same time.

## How to test

```
EXTENSIONS=vscjava.vscode-java-test SKIP_PUBLISH=true FORCE=true GITHUB_TOKEN=YOUR_PAT_HERE node publish-extensions
```

The above should run successfully, you can try any other extension instead of the Java one and to do more at the same time comma-separate them.
