### PR TITLE
Add reporting for most popular Marketplace Extensions

### DIFF
--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -70,4 +70,4 @@ jobs:
     - run: npm install
     - name: Check parity of the top 4096 extensions
       if: ${{ !github.event.inputs.extensions }} # only run on full runs
-      run: lib/reportStat.js
+      run: node lib/reportStat.js

--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -60,7 +60,7 @@ jobs:
         SLACK_WEBHOOK: ${{ secrets.GITPOD_SLACK_WEBHOOK }}
         SLACK_COLOR: ${{ job.status }}
   check_parity:
-    name: Check parity with the Microsoft Marketplace
+    name: Check MS parity
     runs-on: ubuntu-latest
     needs: publish_extensions
     steps:

--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -59,3 +59,15 @@ jobs:
       env:
         SLACK_WEBHOOK: ${{ secrets.GITPOD_SLACK_WEBHOOK }}
         SLACK_COLOR: ${{ job.status }}
+  check_parity:
+    name: Check parity with the Microsoft Marketplace
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3.0.0
+      with:
+        node-version: '14.x'
+    - run: npm install
+    - name: Check parity of the top 4096 extensions
+      if: ${{ !github.event.inputs.extensions }} # only run on full runs
+      run: lib/reportStat.js

--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -52,6 +52,7 @@ jobs:
         name: report
         path: |
           /tmp/stat.json
+          /tmp/meta.json
           /tmp/result.log
     - name: Slack Notification
       if: always()

--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -27,7 +27,7 @@ jobs:
       EXTENSIONS: ${{ github.event.inputs.extensions }}
       SKIP_PUBLISH: ${{ github.event.inputs.skipPublish }}
       FORCE: ${{ github.event.inputs.forcefullyPublish }}
-    name: node publish-extensions
+    name: Publish Extensions
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -62,6 +62,7 @@ jobs:
   check_parity:
     name: Check parity with the Microsoft Marketplace
     runs-on: ubuntu-latest
+    needs: publish_extensions
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3.0.0

--- a/docs/understanding_reports.md
+++ b/docs/understanding_reports.md
@@ -1,12 +1,12 @@
-## Understanding statistics
+# Understanding statistics
 
 This document is here to help you understand reports from [the nightly publishing job](https://github.com/open-vsx/publish-extensions/actions/workflows/publish-extensions.yml).
 
-### How to gather these statistics
+## How to gather these statistics
 
 If you click on a job in the GitHub Actions tab, there is an `Artifacts` section at the bottom of the page, from which you can download the `report`, which after unarchiving reveals two files: `result.log` and `stat.json`.
 
-### `stat.json`
+## `stat.json`
 
 This is the machine-readable data that the next file - `result.log` is generated from. In it, you can find 9 different categories of extensions:
 - `upToDate` - these extensions are the extensions, which have the same version published to OpenVSX as well as the Microsoft Marketplace.
@@ -19,11 +19,11 @@ This is the machine-readable data that the next file - `result.log` is generated
 - `hitMiss`
 - `resolutions` is a list of all extensions and the way they have been resolved: `latest`, `matchedLatest`. `releaseTag`, `tag` or `releaseAsset`.
 
-### `result.log`
+## `result.log`
 
 This file is the one that should provide a quick overview of how the repository is doing. It has many percentages, numbers and sections, so that you can quickly take a look and get the information you want. These are mostly made from the `stat.json` file and pretty self-explanatory, but there are some that are a big more comples:
 
-#### `Weighted publish percentage`
+### `Weighted publish percentage`
 
 This metric's goal is to provide the one number you need to see if the big and most used extensions are up-to-date and existing on OpenVSX. This value is computed as follows (in pseudo-code):
 ```ts
@@ -32,3 +32,7 @@ const totalInstalls = sum(upToDate); // a sum of all install from the Microsoft 
 
 const weightedPublishPercentage = upToDateInstalls / totalInstalls;
 ```
+
+### Microsoft-published extensions
+
+In the `Summary`, you can see a how many extensions published by Microsoft are defined in our repo, how many of them are outdated and how many of them are unstable. For further details with all of the failing extensions, refer to the `MS extensions` section in the file. Under there, you can find more details, like the specific IDs of the extensions and their install counts. 

--- a/docs/understanding_reports.md
+++ b/docs/understanding_reports.md
@@ -4,7 +4,7 @@ This document is here to help you understand reports from [the nightly publishin
 
 ## How to gather these statistics
 
-If you click on a job in the GitHub Actions tab, there is an `Artifacts` section at the bottom of the page, from which you can download the `report`, which after unarchiving reveals two files: `result.log` and `stat.json`.
+If you click on a job in the GitHub Actions tab, there is an `Artifacts` section at the bottom of the page, from which you can download the `report`, which after unarchiving reveals three files: `result.log`, `stat.json` and `meta.json`.
 
 ## `stat.json`
 
@@ -22,7 +22,7 @@ This is the machine-readable data that the next file - `result.log` is generated
 
 ## `result.log`
 
-This file is the one that should provide a quick overview of how the repository is doing. It has many percentages, numbers and sections, so that you can quickly take a look and get the information you want. These are mostly made from the `stat.json` file and pretty self-explanatory, but there are some that are a big more comples:
+This file is the one that should provide a quick overview of how the repository is doing. It has many percentages, numbers and sections, so that you can quickly take a look and get the information you want. These are mostly made from the `stat.json` file and pretty self-explanatory, but there are some that are a bit more complex:
 
 ### `Weighted publish percentage`
 
@@ -38,3 +38,7 @@ const weightedPublishPercentage = upToDateInstalls / totalInstalls;
 ### Microsoft-published extensions
 
 In the `Summary`, you can see a how many extensions published by Microsoft are defined in our repo, how many of them are outdated and how many of them are unstable. For further details with all of the failing extensions, refer to the `MS extensions` section in the file. Under there, you can find more details, like the specific IDs of the extensions and their install counts.
+
+## `meta.json`
+
+Contains metadata that can be used by other jobs wanting to examine data from previous runs. It is not intended to be read by humans.

--- a/docs/understanding_reports.md
+++ b/docs/understanding_reports.md
@@ -13,11 +13,11 @@ This is the machine-readable data that the next file - `result.log` is generated
 - `outdated` are all of the extensions, which have versions on OpenVSX, which are behind the ones on the Microsoft Marketplace. 
 - `unstable` is the category, which has all extensions, that are most likely incorrectly published from the extensions' nightly or beta builds, since on the Microsoft Marketplace has a version which is smaller than the one on OpenVSX.
 - `notInOpen` includes extensions that simply failed to ever be published to OpenVSX, which means they should get special attention - fix them or remove them :)
--  `notInMs` - extensions that aren't published on the Microsoft Marketplace
--  `failed` - the extensions that for some reason failed with their publishing.
--  `msPublished` - all extensions published by Microsoft Corporation.
--  `hitMiss`
--  `resolutions` is a list of all extensions and the way they have been resolved: `latest`, `matchedLatest`. `releaseTag`, `tag` or `releaseAsset`.
+- `notInMs` - extensions that aren't published on the Microsoft Marketplace
+- `failed` - the extensions that for some reason failed with their publishing.
+- `msPublished` - all extensions published by Microsoft Corporation.
+- `hitMiss`
+- `resolutions` is a list of all extensions and the way they have been resolved: `latest`, `matchedLatest`. `releaseTag`, `tag` or `releaseAsset`.
 
 ### `result.log`
 
@@ -28,7 +28,7 @@ This file is the one that should provide a quick overview of how the repository 
 This metric's goal is to provide the one number you need to see if the big and most used extensions are up-to-date and existing on OpenVSX. This value is computed as follows (in pseudo-code):
 ```ts
 const upToDateInstalls = sum(upToDate); // a sum of all installs on the Microsoft Marketplace of all up-to-date extensions 
-const totalInstalls = sum(upToDate); // a sum of all install from the Microsoft Marketplace across both up-to-date extensions, as well as outdated, unstable and failing to publish at all.
+const totalInstalls = sum(upToDate); // a sum of all install from the Microsoft Marketplace across both up-to-date extensions, as well as outdated, unstable and failing to publish at all
 
 const weightedPublishPercentage = upToDateInstalls / totalInstalls;
 ```

--- a/docs/understanding_reports.md
+++ b/docs/understanding_reports.md
@@ -9,14 +9,15 @@ If you click on a job in the GitHub Actions tab, there is an `Artifacts` section
 ## `stat.json`
 
 This is the machine-readable data that the next file - `result.log` is generated from. In it, you can find 9 different categories of extensions:
+
 - `upToDate` - these extensions are the extensions, which have the same version published to OpenVSX as well as the Microsoft Marketplace.
-- `outdated` are all of the extensions, which have versions on OpenVSX, which are behind the ones on the Microsoft Marketplace. 
+- `outdated` are all of the extensions, which have versions on OpenVSX, which are behind the ones on the Microsoft Marketplace.
 - `unstable` is the category, which has all extensions, that are most likely incorrectly published from the extensions' nightly or beta builds, since on the Microsoft Marketplace has a version which is smaller than the one on OpenVSX.
 - `notInOpen` includes extensions that simply failed to ever be published to OpenVSX, which means they should get special attention - fix them or remove them :)
 - `notInMs` - extensions that aren't published on the Microsoft Marketplace
 - `failed` - the extensions that for some reason failed with their publishing.
 - `msPublished` - all extensions published by Microsoft Corporation.
-- `hitMiss`
+- `hitMiss` - extensions which, in <abbr title="Month-To-Date">MTD</abbr>, have been updated on OpenVSX within 2 days after the Microsoft Marketplace.
 - `resolutions` is a list of all extensions and the way they have been resolved: `latest`, `matchedLatest`. `releaseTag`, `tag` or `releaseAsset`.
 
 ## `result.log`
@@ -26,8 +27,9 @@ This file is the one that should provide a quick overview of how the repository 
 ### `Weighted publish percentage`
 
 This metric's goal is to provide the one number you need to see if the big and most used extensions are up-to-date and existing on OpenVSX. This value is computed as follows (in pseudo-code):
+
 ```ts
-const upToDateInstalls = sum(upToDate); // a sum of all installs on the Microsoft Marketplace of all up-to-date extensions 
+const upToDateInstalls = sum(upToDate); // a sum of all installs on the Microsoft Marketplace of all up-to-date extensions
 const totalInstalls = sum(upToDate); // a sum of all install from the Microsoft Marketplace across both up-to-date extensions, as well as outdated, unstable and failing to publish at all
 
 const weightedPublishPercentage = upToDateInstalls / totalInstalls;
@@ -35,4 +37,4 @@ const weightedPublishPercentage = upToDateInstalls / totalInstalls;
 
 ### Microsoft-published extensions
 
-In the `Summary`, you can see a how many extensions published by Microsoft are defined in our repo, how many of them are outdated and how many of them are unstable. For further details with all of the failing extensions, refer to the `MS extensions` section in the file. Under there, you can find more details, like the specific IDs of the extensions and their install counts. 
+In the `Summary`, you can see a how many extensions published by Microsoft are defined in our repo, how many of them are outdated and how many of them are unstable. For further details with all of the failing extensions, refer to the `MS extensions` section in the file. Under there, you can find more details, like the specific IDs of the extensions and their install counts.

--- a/docs/understanding_reports.md
+++ b/docs/understanding_reports.md
@@ -1,0 +1,34 @@
+## Understanding statistics
+
+This document is here to help you understand reports from [the nightly publishing job](https://github.com/open-vsx/publish-extensions/actions/workflows/publish-extensions.yml).
+
+### How to gather these statistics
+
+If you click on a job in the GitHub Actions tab, there is an `Artifacts` section at the bottom of the page, from which you can download the `report`, which after unarchiving reveals two files: `result.log` and `stat.json`.
+
+### `stat.json`
+
+This is the machine-readable data that the next file - `result.log` is generated from. In it, you can find 9 different categories of extensions:
+- `upToDate` - these extensions are the extensions, which have the same version published to OpenVSX as well as the Microsoft Marketplace.
+- `outdated` are all of the extensions, which have versions on OpenVSX, which are behind the ones on the Microsoft Marketplace. 
+- `unstable` is the category, which has all extensions, that are most likely incorrectly published from the extensions' nightly or beta builds, since on the Microsoft Marketplace has a version which is smaller than the one on OpenVSX.
+- `notInOpen` includes extensions that simply failed to ever be published to OpenVSX, which means they should get special attention - fix them or remove them :)
+-  `notInMs` - extensions that aren't published on the Microsoft Marketplace
+-  `failed` - the extensions that for some reason failed with their publishing.
+-  `msPublished` - all extensions published by Microsoft Corporation.
+-  `hitMiss`
+-  `resolutions` is a list of all extensions and the way they have been resolved: `latest`, `matchedLatest`. `releaseTag`, `tag` or `releaseAsset`.
+
+### `result.log`
+
+This file is the one that should provide a quick overview of how the repository is doing. It has many percentages, numbers and sections, so that you can quickly take a look and get the information you want. These are mostly made from the `stat.json` file and pretty self-explanatory, but there are some that are a big more comples:
+
+#### `Weighted publish percentage`
+
+This metric's goal is to provide the one number you need to see if the big and most used extensions are up-to-date and existing on OpenVSX. This value is computed as follows (in pseudo-code):
+```ts
+const upToDateInstalls = sum(upToDate); // a sum of all installs on the Microsoft Marketplace of all up-to-date extensions 
+const totalInstalls = sum(upToDate); // a sum of all install from the Microsoft Marketplace across both up-to-date extensions, as well as outdated, unstable and failing to publish at all.
+
+const weightedPublishPercentage = upToDateInstalls / totalInstalls;
+```

--- a/extensions.json
+++ b/extensions.json
@@ -116,9 +116,6 @@
   "ban.spellright": {
     "repository": "https://github.com/bartosz-antosik/vscode-spellright"
   },
-  "batisteo.vscode-django": {
-    "repository": "https://github.com/vscode-django/vscode-django"
-  },
   "BazelBuild.vscode-bazel": {
     "repository": "https://github.com/bazelbuild/vscode-bazel"
   },

--- a/lib/reportStat.js
+++ b/lib/reportStat.js
@@ -1,0 +1,69 @@
+/********************************************************************************
+ * Copyright (c) 2022 TypeFox and others
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ ********************************************************************************/
+
+// @ts-check
+const fs = require('fs');
+const { getPublicGalleryAPI } = require('vsce/out/util');
+const { PublicGalleryAPI } = require('vsce/out/publicgalleryapi');
+const { ExtensionQueryFlags } = require('azure-devops-node-api/interfaces/GalleryInterfaces');
+
+const msGalleryApi = getPublicGalleryAPI();
+msGalleryApi.client['_allowRetries'] = true;
+msGalleryApi.client['_maxRetries'] = 5;
+
+const openGalleryApi = new PublicGalleryAPI('https://open-vsx.org/vscode', '3.0-preview.1');
+openGalleryApi.client['_allowRetries'] = true;
+openGalleryApi.client['_maxRetries'] = 5;
+openGalleryApi.post = (/** @type {string} */ url, /** @type {string} */ data, /** @type {import("typed-rest-client/Interfaces").IHeaders} */ additionalHeaders) =>
+    openGalleryApi.client.post(`${openGalleryApi.baseUrl}${url}`, data, additionalHeaders);
+
+const flags = [
+    ExtensionQueryFlags.IncludeStatistics,
+    ExtensionQueryFlags.IncludeVersions,
+    ExtensionQueryFlags.IncludeVersionProperties
+];
+
+const checkAmount = 64;
+
+
+(async function () {
+    /**
+     * @type {Readonly<import('../types').Extensions>}
+     */
+     const extensionsToPublish = JSON.parse(await fs.promises.readFile('./extensions.json', 'utf-8'));
+
+    /** @type {import('../types').SingleExtensionQueryResult[]} */
+    const topExtensions = await msGalleryApi.extensionQuery({ pageSize: checkAmount, criteria: [{ filterType: 8, value: "Microsoft.VisualStudio.Code" }, { filterType: 12, value: "4096" }] });
+
+    /** @type {import('../types').SingleExtensionQueryResult[]} */
+    let notInOvsx = [];
+
+
+    for (const extension of topExtensions) {
+        let [msExtension] = await Promise.allSettled([openGalleryApi.getExtension(`${extension.publisher.publisherName}.${extension.extensionName}`, flags)]);
+        if (msExtension.status === "fulfilled") {
+            if (!msExtension.value?.versions[0]?.version) {
+                notInOvsx.push(extension);
+                console.log(`Extension not in OpenVSX: ${extension.publisher.publisherName}.${extension.extensionName}`)
+            }
+        }
+    }
+
+    const microsoftUnpublished = notInOvsx.filter(extension => extension.publisher.domain === 'https://microsoft.com' && extension.publisher.isDomainVerified);
+    const definedInRepo = notInOvsx.filter(extension => extensionsToPublish[`${extension.publisher.publisherName}.${extension.extensionName}`]);
+
+    let summary = '----- Summary -----\r\n';
+    summary += `Total: ${checkAmount}\r\n`;
+    summary += `Not published to OpenVSX: ${notInOvsx.length} (${((notInOvsx.length / checkAmount) * 100).toFixed(4)}%)\r\n`;
+    summary += `Not in OpenVSX but defined in our repo: ${definedInRepo.length} (${((definedInRepo.length / notInOvsx.length) * 100).toFixed(4)}%)\r\n`;
+    summary += `Not published from Microsoft: ${microsoftUnpublished.length} (${((microsoftUnpublished.length / checkAmount) * 100).toFixed(4)}% of all unpublished)\r\n`;
+
+    console.log(summary);
+}());

--- a/lib/reportStat.js
+++ b/lib/reportStat.js
@@ -38,6 +38,7 @@ const cannotPublish = [
 
     // Dependent on ms-dotnettools.csharp
     'vsciot-vscode.vscode-arduino',
+    'Unity.unity-debug',
 
     // Code is proprietary
     'ms-python.vscode-pylance',

--- a/lib/reportStat.js
+++ b/lib/reportStat.js
@@ -38,7 +38,7 @@ const flags = [
     ExtensionQueryFlags.IncludeStatistics,
 ];
 
-const checkAmount = 64;
+const checkAmount = 128;
 
 const cannotPublish = [
     // We cannot redistribute under their license: https://github.com/microsoft/vscode-cpptools/tree/main/RuntimeLicenses
@@ -73,17 +73,18 @@ const cannotPublish = [
 
 /**
  * Checks missing extensions from OpenVSX
- * @param {boolean} silent 
+ * @param {boolean} silent
+ * @param {number} amount 
  * @returns 
  */
-const checkMissing = async (silent = false) => {
+const checkMissing = async (silent = false, amount = checkAmount) => {
     /**
      * @type {Readonly<import('../types').Extensions>}
      */
     const extensionsToPublish = JSON.parse(await fs.promises.readFile('./extensions.json', 'utf-8'));
 
     /** @type {import('../types').SingleExtensionQueryResult[]} */
-    const topExtensions = await msGalleryApi.extensionQuery({ pageSize: checkAmount, criteria: [{ filterType: 8, value: "Microsoft.VisualStudio.Code" }, { filterType: 12, value: "4096" }], flags });
+    const topExtensions = await msGalleryApi.extensionQuery({ pageSize: amount, criteria: [{ filterType: 8, value: "Microsoft.VisualStudio.Code" }, { filterType: 12, value: "4096" }], flags });
 
     /** @type {import('../types').SingleExtensionQueryResult[]} */
     let notInOvsx = [];
@@ -103,9 +104,7 @@ const checkMissing = async (silent = false) => {
                 notInOvsx.push(extension);
                 installs.missing += extInstalls;
                 if (!silent) {
-                    if (cannotPublish.includes(id)) {
-                        console.log(`🟢 Extension not in OpenVSX: ${extension.publisher.publisherName}.${extension.extensionName}`)
-                    } else {
+                    if (!cannotPublish.includes(id)) {
                         console.log(`${popularExtension ? '🔴' : '🟡'} Extension not in OpenVSX : ${extension.publisher.publisherName}.${extension.extensionName}`)
                     }
                 }
@@ -121,11 +120,11 @@ const checkMissing = async (silent = false) => {
     const microsoftCouldPublish = microsoftUnpublished.filter(extension => !cannotPublish.includes(`${extension.publisher.publisherName}.${extension.extensionName}`));
     
     let summary = '----- Summary -----\r\n';
-    summary += `Total: ${checkAmount}\r\n`;
+    summary += `Total: ${amount}\r\n`;
     summary += `Install parity: ${((installs.published / (installs.missing + installs.published)) * 100).toFixed(2)}% (${humanNumber(installs.published, formatter)} out of ${humanNumber(installs.missing + installs.published, formatter)})\r\n`;
-    summary += `Not published to OpenVSX: ${notInOvsx.length} (${((notInOvsx.length / checkAmount) * 100).toFixed(4)}%)\r\n`;
+    summary += `Not published to OpenVSX: ${notInOvsx.length} (${((notInOvsx.length / amount) * 100).toFixed(4)}%)\r\n`;
     summary += `Not in OpenVSX but defined in our repo: ${definedInRepo.length} (${((definedInRepo.length / notInOvsx.length) * 100).toFixed(4)}%)\r\n`;
-    summary += `Not published from Microsoft: ${microsoftUnpublished.length} (${((microsoftUnpublished.length / checkAmount) * 100).toFixed(4)}% of all unpublished)\r\n`;
+    summary += `Not published from Microsoft: ${microsoftUnpublished.length} (${((microsoftUnpublished.length / amount) * 100).toFixed(4)}% of all unpublished)\r\n`;
 
     summary += 'Microsoft extensions we should publish: \r\n'
     summary += microsoftCouldPublish.map(extension => `${extension.publisher.publisherName}.${extension.extensionName}`).join();
@@ -138,6 +137,13 @@ const checkMissing = async (silent = false) => {
         couldPublishMs: microsoftCouldPublish,
         definedInRepo
     }
+}
+
+// Can also be run directly
+if (require.main === module) {
+    (async function() {
+        await checkMissing(false, 4096);
+    }());
 }
 
 exports.checkMissing = checkMissing;

--- a/lib/reportStat.js
+++ b/lib/reportStat.js
@@ -99,7 +99,7 @@ const checkMissing = async (silent = false) => {
     const microsoftUnpublished = notInOvsx.filter(extension => ['https://microsoft.com', 'https://github.com'].includes(extension.publisher.domain) && extension.publisher.isDomainVerified);
     const definedInRepo = notInOvsx.map(ext => `${ext.publisher.publisherName}.${ext.extensionName}`).filter(id => extensionsToPublish[id]);
 
-    const microsoftCouldPublish = microsoftUnpublished.map(extension => `${extension.publisher.publisherName}.${extension.extensionName}`).filter(id => !cannotPublish.includes(id));
+    const microsoftCouldPublish = microsoftUnpublished.filter(extension => !cannotPublish.includes(`${extension.publisher.publisherName}.${extension.extensionName}`));
 
     let summary = '----- Summary -----\r\n';
     summary += `Total: ${checkAmount}\r\n`;
@@ -108,7 +108,7 @@ const checkMissing = async (silent = false) => {
     summary += `Not published from Microsoft: ${microsoftUnpublished.length} (${((microsoftUnpublished.length / checkAmount) * 100).toFixed(4)}% of all unpublished)\r\n`;
 
     summary += 'Microsoft extensions we should publish: \r\n'
-    summary += microsoftCouldPublish.join();
+    summary += microsoftCouldPublish.map(extension => `${extension.publisher.publisherName}.${extension.extensionName}`).join();
 
     if (!silent) console.log(summary);
 

--- a/lib/reportStat.js
+++ b/lib/reportStat.js
@@ -26,12 +26,38 @@ openGalleryApi.post = (/** @type {string} */ url, /** @type {string} */ data, /*
 
 const flags = [
     ExtensionQueryFlags.IncludeStatistics,
-    ExtensionQueryFlags.IncludeVersions,
-    ExtensionQueryFlags.IncludeVersionProperties
 ];
 
-const checkAmount = 64;
+const checkAmount = 128;
 
+const cannotPublish = [
+    // We cannot redistribute under their license: https://github.com/microsoft/vscode-cpptools/tree/main/RuntimeLicenses
+    'ms-vscode.cpptools',
+    'ms-vscode.cpptools-extension-pack',
+    'ms-dotnettools.csharp', // We cannot redistribute under their license: https://github.com/OmniSharp/omnisharp-vscode/tree/master/RuntimeLicenses
+
+    // Dependent on ms-dotnettools.csharp
+    'vsciot-vscode.vscode-arduino',
+
+    // Code is proprietary
+    'ms-python.vscode-pylance',
+    'VisualStudioExptTeam.vscodeintellicode',
+    'ms-vscode-remote.remote-wsl',
+    'ms-vscode-remote.remote-containers',
+    'ms-vscode-remote.remote-ssh',
+    'ms-vscode-remote.remote-ssh-edit',
+    'ms-vscode-remote.vscode-remote-extensionpack',
+    'MS-vsliveshare.vsliveshare',
+    'MS-vsliveshare.vsliveshare-pack',
+
+    // GitHub Proprietary
+    'GitHub.copilot',
+    'GitHub.remotehub',
+    'GitHub.codespaces',
+
+    // Deprecated
+    'eg2.tslint',
+];
 
 (async function () {
     /**
@@ -40,23 +66,28 @@ const checkAmount = 64;
      const extensionsToPublish = JSON.parse(await fs.promises.readFile('./extensions.json', 'utf-8'));
 
     /** @type {import('../types').SingleExtensionQueryResult[]} */
-    const topExtensions = await msGalleryApi.extensionQuery({ pageSize: checkAmount, criteria: [{ filterType: 8, value: "Microsoft.VisualStudio.Code" }, { filterType: 12, value: "4096" }] });
+    const topExtensions = await msGalleryApi.extensionQuery({ pageSize: checkAmount, criteria: [{ filterType: 8, value: "Microsoft.VisualStudio.Code" }, { filterType: 12, value: "4096" }], flags });
 
     /** @type {import('../types').SingleExtensionQueryResult[]} */
     let notInOvsx = [];
 
-
     for (const extension of topExtensions) {
-        let [msExtension] = await Promise.allSettled([openGalleryApi.getExtension(`${extension.publisher.publisherName}.${extension.extensionName}`, flags)]);
-        if (msExtension.status === "fulfilled") {
-            if (!msExtension.value?.versions[0]?.version) {
+        let [openExtension] = await Promise.allSettled([openGalleryApi.getExtension(`${extension.publisher.publisherName}.${extension.extensionName}`, flags)]);
+        const id = `${extension.publisher.publisherName}.${extension.extensionName}`;
+        const popularExtension = extension.statistics?.find(s => s.statisticName === 'install')?.value < 1_000_000;
+        if (openExtension.status === "fulfilled") {
+            if (!openExtension.value?.publisher.publisherId) {
                 notInOvsx.push(extension);
-                console.log(`Extension not in OpenVSX: ${extension.publisher.publisherName}.${extension.extensionName}`)
+                if (cannotPublish.includes(id)) {
+                    console.log(`🟢 Extension not in OpenVSX: ${extension.publisher.publisherName}.${extension.extensionName}`)
+                } else {
+                    console.log(`${popularExtension ? '🔴' : '🟡'} Extension not in OpenVSX : ${extension.publisher.publisherName}.${extension.extensionName}`)
+                }
             }
         }
     }
 
-    const microsoftUnpublished = notInOvsx.filter(extension => extension.publisher.domain === 'https://microsoft.com' && extension.publisher.isDomainVerified);
+    const microsoftUnpublished = notInOvsx.filter(extension => ['https://microsoft.com', 'https://github.com'].includes(extension.publisher.domain) && extension.publisher.isDomainVerified);
     const definedInRepo = notInOvsx.filter(extension => extensionsToPublish[`${extension.publisher.publisherName}.${extension.extensionName}`]);
 
     let summary = '----- Summary -----\r\n';
@@ -64,6 +95,9 @@ const checkAmount = 64;
     summary += `Not published to OpenVSX: ${notInOvsx.length} (${((notInOvsx.length / checkAmount) * 100).toFixed(4)}%)\r\n`;
     summary += `Not in OpenVSX but defined in our repo: ${definedInRepo.length} (${((definedInRepo.length / notInOvsx.length) * 100).toFixed(4)}%)\r\n`;
     summary += `Not published from Microsoft: ${microsoftUnpublished.length} (${((microsoftUnpublished.length / checkAmount) * 100).toFixed(4)}% of all unpublished)\r\n`;
+
+    summary += 'Microsoft extensions we should publish: \r\n'
+    summary += microsoftUnpublished.map(extension => `${extension.publisher.publisherName}.${extension.extensionName}`).filter(id => !cannotPublish.includes(id)).join();
 
     console.log(summary);
 }());

--- a/lib/reportStat.js
+++ b/lib/reportStat.js
@@ -120,9 +120,4 @@ const checkMissing = async (silent = false) => {
     }
 }
 
-(async function () {
-    await checkMissing();
-}());
-
-
 exports.checkMissing = checkMissing;

--- a/lib/reportStat.js
+++ b/lib/reportStat.js
@@ -50,6 +50,7 @@ const cannotPublish = [
     'ms-vscode-remote.vscode-remote-extensionpack',
     'MS-vsliveshare.vsliveshare',
     'MS-vsliveshare.vsliveshare-pack',
+    'MS-vsliveshare.vsliveshare-audio',
 
     // GitHub Proprietary
     'GitHub.copilot',
@@ -60,11 +61,16 @@ const cannotPublish = [
     'eg2.tslint',
 ];
 
-(async function () {
+/**
+ * Checks missing extensions from OpenVSX
+ * @param {boolean} silent 
+ * @returns 
+ */
+const checkMissing = async (silent = false) => {
     /**
      * @type {Readonly<import('../types').Extensions>}
      */
-     const extensionsToPublish = JSON.parse(await fs.promises.readFile('./extensions.json', 'utf-8'));
+    const extensionsToPublish = JSON.parse(await fs.promises.readFile('./extensions.json', 'utf-8'));
 
     /** @type {import('../types').SingleExtensionQueryResult[]} */
     const topExtensions = await msGalleryApi.extensionQuery({ pageSize: checkAmount, criteria: [{ filterType: 8, value: "Microsoft.VisualStudio.Code" }, { filterType: 12, value: "4096" }], flags });
@@ -79,17 +85,21 @@ const cannotPublish = [
         if (openExtension.status === "fulfilled") {
             if (!openExtension.value?.publisher.publisherId) {
                 notInOvsx.push(extension);
-                if (cannotPublish.includes(id)) {
-                    console.log(`🟢 Extension not in OpenVSX: ${extension.publisher.publisherName}.${extension.extensionName}`)
-                } else {
-                    console.log(`${popularExtension ? '🔴' : '🟡'} Extension not in OpenVSX : ${extension.publisher.publisherName}.${extension.extensionName}`)
+                if (!silent) {
+                    if (cannotPublish.includes(id)) {
+                        console.log(`🟢 Extension not in OpenVSX: ${extension.publisher.publisherName}.${extension.extensionName}`)
+                    } else {
+                        console.log(`${popularExtension ? '🔴' : '🟡'} Extension not in OpenVSX : ${extension.publisher.publisherName}.${extension.extensionName}`)
+                    }
                 }
             }
         }
     }
 
     const microsoftUnpublished = notInOvsx.filter(extension => ['https://microsoft.com', 'https://github.com'].includes(extension.publisher.domain) && extension.publisher.isDomainVerified);
-    const definedInRepo = notInOvsx.filter(extension => extensionsToPublish[`${extension.publisher.publisherName}.${extension.extensionName}`]);
+    const definedInRepo = notInOvsx.map(ext => `${ext.publisher.publisherName}.${ext.extensionName}`).filter(id => extensionsToPublish[id]);
+
+    const microsoftCouldPublish = microsoftUnpublished.map(extension => `${extension.publisher.publisherName}.${extension.extensionName}`).filter(id => !cannotPublish.includes(id));
 
     let summary = '----- Summary -----\r\n';
     summary += `Total: ${checkAmount}\r\n`;
@@ -98,7 +108,21 @@ const cannotPublish = [
     summary += `Not published from Microsoft: ${microsoftUnpublished.length} (${((microsoftUnpublished.length / checkAmount) * 100).toFixed(4)}% of all unpublished)\r\n`;
 
     summary += 'Microsoft extensions we should publish: \r\n'
-    summary += microsoftUnpublished.map(extension => `${extension.publisher.publisherName}.${extension.extensionName}`).filter(id => !cannotPublish.includes(id)).join();
+    summary += microsoftCouldPublish.join();
 
-    console.log(summary);
+    if (!silent) console.log(summary);
+
+    return {
+        missing: notInOvsx,
+        missingMs: microsoftUnpublished,
+        couldPublishMs: microsoftCouldPublish,
+        definedInRepo
+    }
+}
+
+(async function () {
+    await checkMissing();
 }());
+
+
+exports.checkMissing = checkMissing;

--- a/lib/reportStat.js
+++ b/lib/reportStat.js
@@ -13,6 +13,16 @@ const fs = require('fs');
 const { getPublicGalleryAPI } = require('vsce/out/util');
 const { PublicGalleryAPI } = require('vsce/out/publicgalleryapi');
 const { ExtensionQueryFlags } = require('azure-devops-node-api/interfaces/GalleryInterfaces');
+const humanNumber = require('human-number');
+
+const formatter = (/** @type {number} */ number) => {
+    const maxDigits = 3;
+    let formatted = number.toFixed(maxDigits);
+    while (formatted.endsWith('0')) {
+        formatted = formatted.slice(0, -1)
+    }
+    return formatted;
+}
 
 const msGalleryApi = getPublicGalleryAPI();
 msGalleryApi.client['_allowRetries'] = true;
@@ -28,7 +38,7 @@ const flags = [
     ExtensionQueryFlags.IncludeStatistics,
 ];
 
-const checkAmount = 128;
+const checkAmount = 64;
 
 const cannotPublish = [
     // We cannot redistribute under their license: https://github.com/microsoft/vscode-cpptools/tree/main/RuntimeLicenses
@@ -78,13 +88,20 @@ const checkMissing = async (silent = false) => {
     /** @type {import('../types').SingleExtensionQueryResult[]} */
     let notInOvsx = [];
 
+    const installs = {
+        published: 0,
+        missing: 0,
+    }
+
     for (const extension of topExtensions) {
         let [openExtension] = await Promise.allSettled([openGalleryApi.getExtension(`${extension.publisher.publisherName}.${extension.extensionName}`, flags)]);
         const id = `${extension.publisher.publisherName}.${extension.extensionName}`;
-        const popularExtension = extension.statistics?.find(s => s.statisticName === 'install')?.value < 1_000_000;
+        const extInstalls = extension.statistics?.find(s => s.statisticName === 'install')?.value;
+        const popularExtension = extInstalls > 1_000_000;
         if (openExtension.status === "fulfilled") {
             if (!openExtension.value?.publisher.publisherId) {
                 notInOvsx.push(extension);
+                installs.missing += extInstalls;
                 if (!silent) {
                     if (cannotPublish.includes(id)) {
                         console.log(`🟢 Extension not in OpenVSX: ${extension.publisher.publisherName}.${extension.extensionName}`)
@@ -92,17 +109,20 @@ const checkMissing = async (silent = false) => {
                         console.log(`${popularExtension ? '🔴' : '🟡'} Extension not in OpenVSX : ${extension.publisher.publisherName}.${extension.extensionName}`)
                     }
                 }
+            } else {
+                installs.published += extInstalls;
             }
         }
     }
-
+    
     const microsoftUnpublished = notInOvsx.filter(extension => ['https://microsoft.com', 'https://github.com'].includes(extension.publisher.domain) && extension.publisher.isDomainVerified);
     const definedInRepo = notInOvsx.map(ext => `${ext.publisher.publisherName}.${ext.extensionName}`).filter(id => extensionsToPublish[id]);
-
+    
     const microsoftCouldPublish = microsoftUnpublished.filter(extension => !cannotPublish.includes(`${extension.publisher.publisherName}.${extension.extensionName}`));
-
+    
     let summary = '----- Summary -----\r\n';
     summary += `Total: ${checkAmount}\r\n`;
+    summary += `Install parity: ${((installs.published / (installs.missing + installs.published)) * 100).toFixed(2)}% (${humanNumber(installs.published, formatter)} out of ${humanNumber(installs.missing + installs.published, formatter)})\r\n`;
     summary += `Not published to OpenVSX: ${notInOvsx.length} (${((notInOvsx.length / checkAmount) * 100).toFixed(4)}%)\r\n`;
     summary += `Not in OpenVSX but defined in our repo: ${definedInRepo.length} (${((definedInRepo.length / notInOvsx.length) * 100).toFixed(4)}%)\r\n`;
     summary += `Not published from Microsoft: ${microsoftUnpublished.length} (${((microsoftUnpublished.length / checkAmount) * 100).toFixed(4)}% of all unpublished)\r\n`;
@@ -121,3 +141,4 @@ const checkMissing = async (silent = false) => {
 }
 
 exports.checkMissing = checkMissing;
+exports.formatter = formatter;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "ajv": "^8.8.1",
     "download": "^8.0.0",
+    "human-number": "^1.0.8",
     "minimist": "^1.2.5",
     "octokit": "^1.7.0",
     "ovsx": "latest",

--- a/publish-extensions.js
+++ b/publish-extensions.js
@@ -100,7 +100,7 @@ function isPreReleaseVersion(version) {
     if (id === '$schema') {
       continue;
     }
-    if (toVerify && toVerify.indexOf(id) === -1) {
+    if (toVerify && toVerify.includes(id)) {
       continue;
     }
     const extension = Object.freeze({ id, ...extensions[id] });

--- a/report-extensions.js
+++ b/report-extensions.js
@@ -212,7 +212,7 @@ function sortedKeys(s) {
         process.exitCode = -1;
     }
 
-    const weightedThreshold = 0.9;
+    const weightedThreshold = 0.8;
 
     if (weightedPercentage < weightedThreshold) {
         // This should indicate a big extension breaking

--- a/report-extensions.js
+++ b/report-extensions.js
@@ -121,9 +121,11 @@ function sortedKeys(s) {
     summary += `Outdated (MS marketplace > Open VSX): ${outdated} (${(outdated / total * 100).toFixed(0)}%)\r\n`;
     summary += `Unstable (MS marketplace < Open VSX): ${unstable} (${(unstable / total * 100).toFixed(0)}%)\r\n`;
     summary += `Not in MS marketplace: ${notInMS} (${(notInMS / total * 100).toFixed(0)}%)\r\n`;
-    summary += `Failed to publish: ${stat.failed.length} (${(stat.failed.length / total * 100).toFixed(0)}%) \r\n`
-    summary += `MS is publisher: ${msPublished} (${(msPublished / total * 100).toFixed(0)}%)\r\n`;
-    summary += `\r\n`;
+    summary += `Failed to publish: ${stat.failed.length} (${(stat.failed.length / total * 100).toFixed(0)}%) \r\n`;
+    summary += `Microsoft:\r\n`;
+    summary += `Total: ${msPublished} (${(msPublished / total * 100).toFixed(0)}%)\r\n`;
+    summary += `Outdated: ${Object.keys(stat.outdated).map(id => Object.keys(stat.msPublished).includes(id)).length}\r\n`;
+    summary += `Unstable: ${Object.keys(stat.unstable).map(id => Object.keys(stat.msPublished).includes(id)).length}\r\n`;
     summary += `Total resolutions: ${totalResolutions}\r\n`;
     summary += `From release asset: ${fromReleaseAsset} (${(fromReleaseAsset / totalResolutions * 100).toFixed(0)}%)\r\n`;
     summary += `From release tag: ${fromReleaseTag} (${(fromReleaseTag / totalResolutions * 100).toFixed(0)}%)\r\n`;

--- a/report-extensions.js
+++ b/report-extensions.js
@@ -137,6 +137,9 @@ function sortedKeys(s) {
 
     const weightedPercentage = (agregatedInstalls.upToDate / ( agregatedInstalls.notInOpen + agregatedInstalls.upToDate + agregatedInstalls.outdated + agregatedInstalls.unstable ));
 
+    // Get missing extensions from Microsoft
+    const { couldPublishMs, missingMs, definedInRepo } = await checkMissing(true);
+
     let summary = '----- Summary -----\r\n';
     summary += `Total: ${total}\r\n`;
     summary += `Up-to-date (MS Marketplace == Open VSX): ${upToDate} (${(upToDate / total * 100).toFixed(0)}%) (${upToDateChange !== undefined ? `${upToDateChange ? `${Math.abs(upToDateChange).toFixed(3)}% ` : ''}${upToDateChange > 0 ? 'increase' : upToDateChange === 0 ? 'no change' : 'decrease'} since last week` : "WoW change n/a"})\r\n`;
@@ -150,6 +153,7 @@ function sortedKeys(s) {
     summary += `Total: ${msPublished} (${(msPublished / total * 100).toFixed(0)}%)\r\n`;
     summary += `Outdated: ${msPublishedOutdated.length}\r\n`;
     summary += `Unstable: ${msPublishedUnstable.length}\r\n`;
+    summary += `Missing: ${missingMs.length} (we could publish ${couldPublishMs.length} out of that)`
     summary += `Total resolutions: ${totalResolutions}\r\n`;
     summary += `From release asset: ${fromReleaseAsset} (${(fromReleaseAsset / totalResolutions * 100).toFixed(0)}%)\r\n`;
     summary += `From release tag: ${fromReleaseTag} (${(fromReleaseTag / totalResolutions * 100).toFixed(0)}%)\r\n`;
@@ -245,8 +249,6 @@ function sortedKeys(s) {
 
         content += '-------------------\r\n';
         content += '\r\n----- MS missing from OpenVSX -----\r\n'
-
-        const { couldPublishMs, definedInRepo } = await checkMissing(true);
 
         for (const extension of couldPublishMs) {
             content += `${`${extension.publisher.publisherName}.${extension.extensionName}`} (installs: ${extension.statistics?.find(s => s.statisticName === 'install')?.value}})${definedInRepo.includes(`${extension.publisher.publisherName}.${extension.extensionName}`) ? ` [defined in extensions.json]` : ''}\r\n`;

--- a/report-extensions.js
+++ b/report-extensions.js
@@ -224,9 +224,8 @@ function sortedKeys(s) {
 
         const { couldPublishMs, definedInRepo } = await checkMissing(true);
 
-        for (const id of couldPublishMs) {
-            const r = stat.msPublished[id];
-            content += `${id} (installs: ${r.msInstalls})${definedInRepo.includes(id) ? ` [defined in extensions.json]` : ''}\r\n`;
+        for (const extension of couldPublishMs) {
+            content += `${`${extension.publisher.publisherName}.${extension.extensionName}`} (installs: ${extension.statistics?.find(s => s.statisticName === 'install')?.value}})${definedInRepo.includes(`${extension.publisher.publisherName}.${extension.extensionName}`) ? ` [defined in extensions.json]` : ''}\r\n`;
         }
 
         content += '-------------------\r\n';

--- a/report-extensions.js
+++ b/report-extensions.js
@@ -174,7 +174,7 @@ function sortedKeys(s) {
     summary += `Total: ${msPublished} (${(msPublished / total * 100).toFixed(0)}%)\r\n`;
     summary += `Outdated: ${msPublishedOutdated.length}\r\n`;
     summary += `Unstable: ${msPublishedUnstable.length}\r\n`;
-    summary += `Missing: ${missingMs.length} (we could publish ${couldPublishMs.length} out of that)`
+    summary += `Missing: ${missingMs.length} (we could publish ${couldPublishMs.length} out of that)\r\n`
     summary += `Total resolutions: ${totalResolutions}\r\n`;
     summary += `From release asset: ${fromReleaseAsset} (${(fromReleaseAsset / totalResolutions * 100).toFixed(0)}%)\r\n`;
     summary += `From release tag: ${fromReleaseTag} (${(fromReleaseTag / totalResolutions * 100).toFixed(0)}%)\r\n`;

--- a/report-extensions.js
+++ b/report-extensions.js
@@ -13,6 +13,7 @@ const fs = require('fs');
 const Octokit = require('octokit').Octokit;
 const exec = require('./lib/exec');
 const { checkMissing } = require('./lib/reportStat');
+const humanNumber = require('human-number');
 
 const token = process.env.GITHUB_TOKEN;
 if (!token) {
@@ -152,7 +153,7 @@ function sortedKeys(s) {
         content += '\r\n----- Outdated (MS marketplace > Open VSX version) -----\r\n';
         for (const id of sortedKeys(stat.outdated)) {
             const r = stat.outdated[id];
-            content += `${id} (installs: ${r.msInstalls}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.msVersion} > ${r.openVersion}\r\n`;
+            content += `${id} (installs: ${humanNumber(r.msInstalls)}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.msVersion} > ${r.openVersion}\r\n`;
         }
         content += '-------------------\r\n';
     }
@@ -164,7 +165,7 @@ function sortedKeys(s) {
         content += '\r\n----- Not published to Open VSX, but in MS marketplace -----\r\n';
         for (const id of Object.keys(stat.notInOpen).sort((a, b) => stat.notInOpen[b].msInstalls - stat.notInOpen[a].msInstalls)) {
             const r = stat.notInOpen[id];
-            content += `${id} (installs: ${r.msInstalls}): ${r.msVersion}\r\n`;
+            content += `${id} (installs: ${humanNumber(r.msInstalls)}): ${r.msVersion}\r\n`;
         }
         content += '-------------------\r\n';
     }
@@ -176,7 +177,7 @@ function sortedKeys(s) {
         content += '\r\n----- Unstable (Open VSX > MS marketplace version) -----\r\n';
         for (const id of sortedKeys(stat.unstable)) {
             const r = stat.unstable[id];
-            content += `${id} (installs: ${r.msInstalls}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.openVersion} > ${r.msVersion}\r\n`;
+            content += `${id} (installs: ${humanNumber(r.msInstalls)}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.openVersion} > ${r.msVersion}\r\n`;
         }
         content += '-------------------\r\n';
     }
@@ -199,7 +200,7 @@ function sortedKeys(s) {
         content += '\r\n----- MS extensions -----\r\n'
         for (const id of Object.keys(stat.msPublished).sort((a, b) => stat.msPublished[b].msInstalls - stat.msPublished[a].msInstalls)) {
             const r = stat.msPublished[id];
-            content += `${id} (installs: ${r.msInstalls})\r\n`;
+            content += `${id} (installs: ${humanNumber(r.msInstalls)})\r\n`;
         }
 
         content += '-------------------\r\n';
@@ -207,7 +208,7 @@ function sortedKeys(s) {
 
         for (const id of msPublishedOutdated.sort((a, b) => stat.msPublished[b].msInstalls - stat.msPublished[a].msInstalls)) {
             const r = stat.msPublished[id];
-            content += `${id} (installs: ${r.msInstalls})\r\n`;
+            content += `${id} (installs: ${humanNumber(r.msInstalls)})\r\n`;
         }
 
 
@@ -216,7 +217,7 @@ function sortedKeys(s) {
 
         for (const id of msPublishedUnstable.sort((a, b) => stat.msPublished[b].msInstalls - stat.msPublished[a].msInstalls)) {
             const r = stat.msPublished[id];
-            content += `${id} (installs: ${r.msInstalls})\r\n`;
+            content += `${id} (installs: ${humanNumber(r.msInstalls)})\r\n`;
         }
 
         content += '-------------------\r\n';
@@ -238,7 +239,7 @@ function sortedKeys(s) {
             const in2Days = updatedInOpenIn2Days.has(id) ? '+' : '-';
             const in2Weeks = updatedInOpenIn2Weeks.has(id) ? '+' : '-';
             const inMonth = updatedInOpenInMonth.has(id) ? '+' : '-';
-            content += `${inMonth}${in2Weeks}${in2Days} ${id}: installs: ${r.msInstalls}; daysInBetween: ${r.daysInBetween?.toFixed(0)}; MS marketplace: ${r.msVersion}; Open VSX: ${r.openVersion}\r\n`;
+            content += `${inMonth}${in2Weeks}${in2Days} ${id}: installs: ${humanNumber(r.msInstalls)}; daysInBetween: ${r.daysInBetween?.toFixed(0)}; MS marketplace: ${r.msVersion}; Open VSX: ${r.openVersion}\r\n`;
         }
         content += '-------------------\r\n';
     }
@@ -247,7 +248,7 @@ function sortedKeys(s) {
         content += '\r\n----- Up-to-date (Open VSX = MS marketplace version) -----\r\n';
         for (const id of Object.keys(stat.upToDate).sort((a, b) => stat.upToDate[b].msInstalls - stat.upToDate[a].msInstalls)) {
             const r = stat.upToDate[id];
-            content += `${id} (installs: ${r.msInstalls}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.openVersion}\r\n`;
+            content += `${id} (installs: ${humanNumber(r.msInstalls)}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.openVersion}\r\n`;
         }
         content += '-------------------\r\n';
     }
@@ -257,23 +258,23 @@ function sortedKeys(s) {
         for (const id of sortedKeys(stat.resolutions)) {
             const r = stat.resolutions[id];
             if (r?.releaseAsset) {
-                content += `${id} (installs: ${r.msInstalls}): from '${r.releaseAsset}' release asset\r\n`;
+                content += `${id} (installs: ${humanNumber(r.msInstalls)}): from '${r.releaseAsset}' release asset\r\n`;
             } else if (r?.releaseTag) {
-                content += `${id} (installs: ${r.msInstalls}): from '${r.releaseTag}' release tag\r\n`;
+                content += `${id} (installs: ${humanNumber(r.msInstalls)}): from '${r.releaseTag}' release tag\r\n`;
             } else if (r?.tag) {
-                content += `${id} (installs: ${r.msInstalls}): from '${r.tag}' release repo tag\r\n`;
+                content += `${id} (installs: ${humanNumber(r.msInstalls)}): from '${r.tag}' release repo tag\r\n`;
             } else if (r?.latest) {
                 if (r.msVersion) {
-                    content += `${id} (installs: ${r.msInstalls}): from '${r.latest}' the very latest repo commit, since it is not actively maintained\r\n`;
+                    content += `${id} (installs: ${humanNumber(r.msInstalls)}): from '${r.latest}' the very latest repo commit, since it is not actively maintained\r\n`;
                 } else {
-                    content += `${id} (installs: ${r.msInstalls}): from '${r.latest}' the very latest repo commit, since it is not published to MS marketplace\r\n`;
+                    content += `${id} (installs: ${humanNumber(r.msInstalls)}): from '${r.latest}' the very latest repo commit, since it is not published to MS marketplace\r\n`;
                 }
             } else if (r?.matchedLatest) {
-                content += `${id} (installs: ${r.msInstalls}): from '${r.matchedLatest}' from the very latest commit on the last update date\r\n`;
+                content += `${id} (installs: ${humanNumber(r.msInstalls)}): from '${r.matchedLatest}' from the very latest commit on the last update date\r\n`;
             } else if (r?.matched) {
-                content += `${id} (installs: ${r.msInstalls}): from '${r.matched}' from the latest commit on the last update date\r\n`;
+                content += `${id} (installs: ${humanNumber(r.msInstalls)}): from '${r.matched}' from the latest commit on the last update date\r\n`;
             } else {
-                content += `${id} (installs: ${r.msInstalls}): unresolved\r\n`;
+                content += `${id} (installs: ${humanNumber(r.msInstalls)}): unresolved\r\n`;
             }
         }
         content += '-------------------\r\n';

--- a/types.d.ts
+++ b/types.d.ts
@@ -63,7 +63,13 @@ export interface SingleExtensionQueryResult {
     releaseDate: string
     shortDescription: string
     deploymentType: number
+    statistics: Statistic[]
 };
+
+export interface Statistic {
+    statisticName: string
+    value: number
+}
 
 export interface Publisher {
     publisherId: string

--- a/types.d.ts
+++ b/types.d.ts
@@ -52,6 +52,28 @@ export interface Extensions {
     [id: string]: Omit<Extension, 'id'>
 }
 
+export interface SingleExtensionQueryResult {
+    publisher: Publisher
+    extensionId: string
+    extensionName: string
+    displayName: string
+    flags: number
+    lastUpdated: string
+    publishedDate: string
+    releaseDate: string
+    shortDescription: string
+    deploymentType: number
+};
+
+export interface Publisher {
+    publisherId: string
+    publisherName: string
+    displayName: string
+    flags: number
+    domain: string
+    isDomainVerified: boolean
+}
+
 export interface Extension {
     id: string,
     repository?: string
@@ -92,6 +114,6 @@ export interface PublishContext {
 }
 
 interface IRawGalleryExtensionProperty {
-	readonly key: string;
-	readonly value: string;
+    readonly key: string;
+    readonly value: string;
 }


### PR DESCRIPTION
## Description

This PR adds a script which reports stats about the most popular extensions from MS which we don't have on OpenVSX, maybe pointing us to extensions which we don't have from Microsoft or which we should ask their maintainers about.

It also adds docs about understanding the reports that the GitHub Action generates as well as some quality of life improvements in the publishing and reporting scripts.

## How to test

- For the docs part, check it out and read through it
- For the reporting part, check the [workflow run](https://github.com/open-vsx/publish-extensions/actions/runs/2383294147) to see what it produces