### PR TITLE
Add `tomoki1207.pdf`

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1122,6 +1122,9 @@
   "tombonnike.vscode-status-bar-format-toggle": {
     "repository": "https://github.com/Tom-Bonnike/vscode-formatting-toggle"
   },
+  "tomoki1207.pdf": {
+    "repository": "https://github.com/tomoki1207/vscode-pdfviewer"
+  },
   "tonsky.theme-alabaster": {
     "repository": "https://github.com/tonsky/vscode-theme-alabaster"
   },


### PR DESCRIPTION
:wave:, To the best of my knowledge, I'm following etiquette for getting https://github.com/tomoki1207/vscode-pdfviewer into Open VSX.

- The repository's last commit was a few months ago, so I take it that the repo is maintained
- There was an issue opened a year prior to the latest commit about Open VSX here: https://github.com/tomoki1207/vscode-pdfviewer/issues/89
- The [package.json](https://github.com/tomoki1207/vscode-pdfviewer/blob/3eb12b46f6374630118f4af52e35f948271321f4/package.json#L94) seems like it meets the criteria here for not needing additional build steps
- The extension has id `tomoki1207.pdf` (pasted from here: https://marketplace.visualstudio.com/items?itemName=tomoki1207.pdf)
- The repo has an MIT [LICENSE](https://github.com/tomoki1207/vscode-pdfviewer/blob/master/LICENSE)

<!--

### For community contributors

For the sake of efficiency and simplicity, the easiest way to publish an extension is by having it published by its maintainers, for more info about this please refer to the [README](https://github.com/open-vsx/publish-extensions#when-to-add-an-extension). If the authors are open to publish the extension to OpenVSX, you can help them by contributing a GitHub Action using our handy-dandy [direct publish setup](docs/direct_publish_setup.md) doc.

 - If the extension is unmaintained, please create an issue for it instead.

For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

-->

- [x] I have read the note above about PRs contributing or fixing extensions
- [x] I have tried reaching out to the extension maintainers about publishing this extension to OpenVSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).
- [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description

<!-- Please do not leave this blank -->

This PR introduces adding `tomoki1207.pdf` change to add it to Open VSX. The extension does not seem unmaintained, but the issue for adding it to OpenVSX has not been responded to: https://github.com/tomoki1207/vscode-pdfviewer/issues/89.
