### PR TITLE
Remove kodetech-extensions

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -602,18 +602,6 @@
   "KnisterPeter.vscode-github": {
     "repository": "https://github.com/KnisterPeter/vscode-github"
   },
-  "kodetech.electron-debug": {
-    "repository": "https://github.com/Kode/vscode-electron-debug"
-  },
-  "kodetech.kha": {
-    "repository": "https://github.com/Kode/vscode-kha"
-  },
-  "kodetech.kha-extension-pack": {
-    "repository": "https://github.com/Kode/vscode-kha-extension-pack"
-  },
-  "kodetech.krafix": {
-    "repository": "https://github.com/Kode/vscode-krafix"
-  },
   "korekontrol.saltstack": {
     "repository": "https://github.com/korekontrol/vscode-saltstack"
   },


### PR DESCRIPTION
This PR removes all extensions from the kodetech-organization. I would like to take care of those myself from now on (see https://github.com/EclipseFdn/open-vsx.org/issues/895).