### PR TITLE
Abort Publish Process if a Command Fails

### DIFF
--- a/lib/exec.js
+++ b/lib/exec.js
@@ -14,7 +14,7 @@ const cp = require('child_process');
 /**
  * @param {string} command
  * @param {{cwd?: string, quiet?: boolean}} [options]
- * @returns {Promise<{ stdout: string, stderr: string }>}
+ * @returns {Promise<{ stdout: string, stderr: string, exitCode: number }>}
  */
 module.exports = async (command, options) => {
   if (!options?.quiet) {
@@ -32,7 +32,7 @@ module.exports = async (command, options) => {
       if (error) {
         return reject(error);
       }
-      resolve({ stdout, stderr });
+      resolve({ stdout, stderr, exitCode: child.exitCode });
     });
     if (!options?.quiet) {
       child.stdout.pipe(process.stdout);

--- a/publish-extension.js
+++ b/publish-extension.js
@@ -43,7 +43,7 @@ const { createVSIX } = require('vsce');
                 try {
                     for (const command of extension.custom) {
                         const result = await exec(command, { cwd: context.repo });
-                        if (result.exitCode > 0) {
+                        if (result.exitCode != 0) {
                             throw new Error(
                                 `An error occurred during the execution of "${command}":\n` +
                                 `stdout:\n${result.stdout}\n` +

--- a/publish-extension.js
+++ b/publish-extension.js
@@ -44,7 +44,10 @@ const { createVSIX } = require('vsce');
                     for (const command of extension.custom) {
                         const result = await exec(command, { cwd: context.repo });
                         if (result.exitCode > 0) {
-                            throw new Error(`An error occurred during the execution of "${command}":\n${result.stderr}`);
+                            throw new Error(
+                                `An error occurred during the execution of "${command}":\n` +
+                                `stdout:\n${result.stdout}\n` +
+                                `stderr:\n${result.stderr}`);
                         }
                     }
                     options = { extensionFile: path.join(context.repo, extension.location, 'extension.vsix') };

--- a/publish-extension.js
+++ b/publish-extension.js
@@ -43,7 +43,7 @@ const { createVSIX } = require('vsce');
                 try {
                     for (const command of extension.custom) {
                         const result = await exec(command, { cwd: context.repo });
-                        if (result.stderr.length > 0) {
+                        if (result.exitCode > 0) {
                             throw new Error(`An error occurred during the execution of "${command}":\n${result.stderr}`);
                         }
                     }

--- a/publish-extension.js
+++ b/publish-extension.js
@@ -42,7 +42,10 @@ const { createVSIX } = require('vsce');
             if (extension.custom) {
                 try {
                     for (const command of extension.custom) {
-                        await exec(command, { cwd: context.repo });
+                        const result = await exec(command, { cwd: context.repo });
+                        if (result.stderr.length > 0) {
+                            throw new Error(`An error occurred during the execution of "${command}":\n${result.stderr}`);
+                        }
                     }
                     options = { extensionFile: path.join(context.repo, extension.location, 'extension.vsix') };
                 } catch (e) {


### PR DESCRIPTION
## Description
Currently, the `custom` property accepts a set of commands which are executed in order.
If an error occurrs, the commands which follow will still be executed. I think it might be a good idea to prevent extensions with failing commands form being published because this could lead to potentially broken extensions.

Changes made in this PR will make sure that the exit code equals 0. If the exit code doesn't equal 0, the `stdout` and `stderr` will be dumped and the publish-process of the corresponding extension will be aborted.