### PR TITLE
README.md: give publish-extensions.js a token

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Click the button below to start a [Gitpod](https://gitpod.io) workspace where yo
 
 The best way to add an extension here is to [open this repository in Gitpod](https://gitpod.io/#https://github.com/open-vsx/publish-extensions) and [add a new entry to `extensions.json`](#how-to-add-an-extension). To test, run:
 ```
-EXTENSIONS=rebornix.ruby SKIP_PUBLISH=true node publish-extensions.js
+EXTENSIONS=rebornix.ruby GITHUB_TOKEN=nada SKIP_PUBLISH=true node publish-extensions.js
 ```
 
 Notes:


### PR DESCRIPTION
For some reason, publish-extensions.js dies without a `GITHUB_TOKEN` environment variable,
even though the value seems to be irrelevant (in `SKIP_PUBLISH` mode).