### PR TITLE
Remove Dart-Code extensions which are being published manually

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -206,12 +206,6 @@
   "Dannark.AndroidLauncher": {
     "repository": "https://github.com/Dannark/Android-Launcher-for-VSCode"
   },
-  "Dart-Code.dart-code": {
-    "repository": "https://github.com/Dart-Code/Dart-Code"
-  },
-  "Dart-Code.flutter": {
-    "repository": "https://github.com/Dart-Code/Flutter"
-  },
   "DavidAnson.vscode-markdownlint": {
     "repository": "https://github.com/DavidAnson/vscode-markdownlint",
     "prepublish": "npm run compile"


### PR DESCRIPTION
I'm the author of the Dart/Flutter extensions and publishing these to open-vsx manually. This script published an update before I did yesterday, which results in it showing as "unverified" (whereas those published by me are verified).

I intend to continue publishing these extensions for the foreseeable future, so it would be better if this script doesn't beat me to it :-)

See https://github.com/EclipseFdn/open-vsx.org/issues/945.
