### PR TITLE
adding kdcro101.favorites

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -575,6 +575,9 @@
   "karunamurti.rspec-snippets": {
     "repository": "https://github.com/karuna/vscode-rspec-snippets"
   },
+  "kdcro101.favorites": {
+    "repository": "https://github.com/kdcro101/vscode-favorites"
+  },
   "Kelvin.vscode-sshfs": {
     "repository": "https://github.com/SchoofsKelvin/vscode-sshfs"
   },


### PR DESCRIPTION
- [X] I have read the note above about PRs contributing or fixing extensions
- [X] I have tried reaching out to the extension maintainers about publishing this extension to OpenVSX:  https://github.com/kdcro101/vscode-favorites/issues/52
- [X] This extension has an [OSI-approved OSS license](https://opensource.org/licenses): MIT

## Description

This PR introduces adds kdcro101.favorites which is currently missing and quite useful.
