### PR TITLE
Fix Typo in Org Mode Workaround

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1232,7 +1232,7 @@
     "custom": [
       "[ $MS_VERSION = '1.0.0' ] && git checkout e8cc69868af427f5fd03c8ad125b493cbf2e8292 || true",
       "[ $MS_VERSION = '1.0.0' ] && npm remove --save-dev vscode && npm install --save-dev typescript@3 @types/vscode@1.23 @types/node@7 || true",
-      "[ $MS_VERSION = '1.0.0' ] && sed -i '/\"categories\":\\s*\\[/,/\\[/{s/\\(\"\\)\\(Languages\"\\)/\\1Programming \\2/g}' package.json || true",
+      "[ $MS_VERSION = '1.0.0' ] && sed -i '/\"categories\":\\s*\\[/,/\\]/{s/\\(\"\\)\\(Languages\"\\)/\\1Programming \\2/g}' package.json || true",
       "[ $MS_VERSION = '1.0.0' ] && sed -i '/\"postinstall\": \".*\"/d' package.json || true",
       "npm install",
       "vsce package -o extension.vsix"


### PR DESCRIPTION
- [x] I have read the note above about PRs contributing or fixing extensions
- [ ] ~~I have tried reaching out to the extension maintainers about publishing this extension to OpenVSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).~~
- [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description
A short time ago, I added a workaround to make publishing the `vscode-org-mode.org-mode` work again.
However, I made a little mistake and mistyped a single symbol.

Merging this PR is not urgent as the workaround seems to work despite the fact that there is a typo.
