### PR TITLE
Replace C# Godot's dependencies with `muhammad-sammy.csharp`

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -914,7 +914,8 @@
     "timeout": 10,
     "custom": [
       "[ $VERSION = '0.2.1' ] && npm install --save-dev webpack@5.70.0 webpack-cli@4.9.2 || true",
-      "cat <<< $(jq --argjson deps '[ \"muhammad-sammy.csharp\" ]' '.extensionDependencies = $deps' package.json) > package.json",
+      "jq --argjson deps '[ \"muhammad-sammy.csharp\" ]' '.extensionDependencies = $deps' package.json > .package.json",
+      "mv --force .package.json package.json",
       "echo 'apt-get update -y' > /tmp/build-godot.sh",
       "echo 'apt-get install -y apt-transport-https dirmngr gnupg ca-certificates' >> /tmp/build-godot.sh",
       "echo 'apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF' >> /tmp/build-godot.sh",

--- a/extensions.json
+++ b/extensions.json
@@ -914,7 +914,7 @@
     "timeout": 10,
     "custom": [
       "[ $VERSION = '0.2.1' ] && npm install --save-dev webpack@5.70.0 webpack-cli@4.9.2 || true",
-      "cat package.json | jq --argjson deps '[ \"muhammad-sammy.csharp\" ]' '.extensionDependencies = $deps' > package.json",
+      "cat <<< $(jq --argjson deps '[ \"muhammad-sammy.csharp\" ]' '.extensionDependencies = $deps' package.json) > package.json",
       "echo 'apt-get update -y' > /tmp/build-godot.sh",
       "echo 'apt-get install -y apt-transport-https dirmngr gnupg ca-certificates' >> /tmp/build-godot.sh",
       "echo 'apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF' >> /tmp/build-godot.sh",

--- a/extensions.json
+++ b/extensions.json
@@ -914,8 +914,7 @@
     "timeout": 10,
     "custom": [
       "[ $VERSION = '0.2.1' ] && npm install --save-dev webpack@5.70.0 webpack-cli@4.9.2 || true",
-      "sed -i '/\"extensionDependencies\":\\s*\\[/,/\\]/{/^\\s*\".*\",\\?$/d}' package.json || true",
-      "sed -i '/\"extensionDependencies\":\\s*\\[/a \"muhammad-sammy.csharp\"' package.json || true",
+      "cat package.json | jq --argjson deps '[ \"muhammad-sammy.csharp\" ]' '.extensionDependencies = $deps' > package.json",
       "echo 'apt-get update -y' > /tmp/build-godot.sh",
       "echo 'apt-get install -y apt-transport-https dirmngr gnupg ca-certificates' >> /tmp/build-godot.sh",
       "echo 'apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF' >> /tmp/build-godot.sh",

--- a/extensions.json
+++ b/extensions.json
@@ -914,6 +914,8 @@
     "timeout": 10,
     "custom": [
       "[ $VERSION = '0.2.1' ] && npm install --save-dev webpack@5.70.0 webpack-cli@4.9.2 || true",
+      "sed -i '/\"extensionDependencies\":\\s*\\[/,/\\]/{/^\\s*\".*\",\\?$/d}' package.json || true",
+      "sed -i '/\"extensionDependencies\":\\s*\\[/a \"muhammad-sammy.csharp\"' package.json || true",
       "echo 'apt-get update -y' > /tmp/build-godot.sh",
       "echo 'apt-get install -y apt-transport-https dirmngr gnupg ca-certificates' >> /tmp/build-godot.sh",
       "echo 'apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF' >> /tmp/build-godot.sh",


### PR DESCRIPTION
- [x] I have read the note above about PRs contributing or fixing extensions
- [x] I have tried reaching out to the extension maintainers about publishing this extension to OpenVSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)). (see https://github.com/godotengine/godot-csharp-vscode/issues/12)
- [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description
In a workaround I've created a short time ago, I added the `neikeq.godot-csharp-vscode` extension.
However, this extension couldn't be published as it depends on extensions which aren't available in the open-vsx store.

Thus, changes made in this PR will change the dependencies to their corresponding open source variants.
In doing so, changes made in this PR will fix the publishing process of the `neikeq.godot-csharp-vscode` extension.
