### PR TITLE
Replace `felixfbecker.php-pack` with `xdebug.php-pack`

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -330,8 +330,8 @@
   "felipecaputo.git-project-manager": {
     "repository": "https://github.com/felipecaputo/git-project-manager"
   },
-  "felixfbecker.php-pack": {
-    "repository": "https://github.com/felixfbecker/vscode-php-pack"
+  "xdebug.php-pack": {
+    "repository": "https://github.com/zobo/vscode-php-pack"
   },
   "fernandoescolar.vscode-solution-explorer": {
     "repository": "https://github.com/fernandoescolar/vscode-solution-explorer"


### PR DESCRIPTION
The extension repository is no longer active and has been moved, along with a new publisher.

- [ ] Publish `xdebug.php-debug` https://github.com/xdebug/vscode-php-debug/issues/807
- [x] Publish `zobo.php-intellisense`