### PR TITLE
Add purduesigbots.pros-vsc

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1000,6 +1000,9 @@
   "pucelle.vscode-css-navigation": {
     "repository": "https://github.com/pucelle/vscode-css-navigation"
   },
+  "purduesigbots.pros-vsc": {
+    "repository": "https://github.com/purduesigbots/pros-vsc"
+  },
   "rafaelmaiolla.diff": {
     "repository": "https://github.com/rafaelmaiolla/diff-vscode"
   },


### PR DESCRIPTION
- [x] I have read the note above about PRs contributing or fixing extensions
- [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description

This PR adds the PROS-VSC Extension
