### PR TITLE
Make reporting be done in markdown

### DIFF
--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -53,7 +53,9 @@ jobs:
         path: |
           /tmp/stat.json
           /tmp/meta.json
-          /tmp/result.log
+          /tmp/result.md
+    - name: Upload job summary
+      run: cat /tmp/result.md >> $GITHUB_STEP_SUMMARY
     - name: Slack Notification
       if: always()
       uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -32,5 +32,6 @@ jobs:
           name: report
           path: |
             /tmp/stat.json
-            /tmp/result.log
-
+            /tmp/result.md
+      - name: Upload job summary
+        run: cat /tmp/result.md >> $GITHUB_STEP_SUMMARY

--- a/docs/understanding_reports.md
+++ b/docs/understanding_reports.md
@@ -4,11 +4,11 @@ This document is here to help you understand reports from [the nightly publishin
 
 ## How to gather these statistics
 
-If you click on a job in the GitHub Actions tab, there is an `Artifacts` section at the bottom of the page, from which you can download the `report`, which after unarchiving reveals three files: `result.log`, `stat.json` and `meta.json`.
+If you click on a job in the GitHub Actions tab, there is an `Artifacts` section at the bottom of the page, from which you can download the `report`, which after unarchiving reveals three files: `result.md`, `stat.json` and `meta.json`.
 
 ## `stat.json`
 
-This is the machine-readable data that the next file - `result.log` is generated from. In it, you can find 9 different categories of extensions:
+This is the machine-readable data that the next file - `result.md` is generated from. In it, you can find 9 different categories of extensions:
 
 - `upToDate` - these extensions are the extensions, which have the same version published to OpenVSX as well as the Microsoft Marketplace.
 - `outdated` are all of the extensions, which have versions on OpenVSX, which are behind the ones on the Microsoft Marketplace.
@@ -20,7 +20,7 @@ This is the machine-readable data that the next file - `result.log` is generated
 - `hitMiss` - extensions which, in <abbr title="Month-To-Date">MTD</abbr>, have been updated on OpenVSX within 2 days after the Microsoft Marketplace.
 - `resolutions` is a list of all extensions and the way they have been resolved: `latest`, `matchedLatest`. `releaseTag`, `tag` or `releaseAsset`.
 
-## `result.log`
+## `result.md`
 
 This file is the one that should provide a quick overview of how the repository is doing. It has many percentages, numbers and sections, so that you can quickly take a look and get the information you want. These are mostly made from the `stat.json` file and pretty self-explanatory, but there are some that are a bit more complex:
 

--- a/report-extensions.js
+++ b/report-extensions.js
@@ -54,9 +54,7 @@ function positionOf(item, array) {
     return `${array.indexOf(item) + 1}.`;
 }
 
-function generateLink = () => {
-    
-}
+const generateLink = (/** @type {string} */ id) =>  `[${id}](https://marketplace.visualstudio.com/items?itemName=${id})`;
 
 (async () => {
 
@@ -251,7 +249,7 @@ function generateLink = () => {
         content += '\r\n## Outdated (MS marketplace > Open VSX version)\r\n';
         for (const id of keys) {
             const r = stat.outdated[id];
-            content += `${positionOf(id, keys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.msVersion} > ${r.openVersion}\r\n`;
+            content += `${positionOf(id, keys)} ${generateLink(id)} (installs: ${humanNumber(r.msInstalls, formatter)}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.msVersion} > ${r.openVersion}\r\n`;
         }
         content += '\r\n---\r\n';
     }
@@ -261,7 +259,7 @@ function generateLink = () => {
         content += '\r\n## Not published to Open VSX, but in MS marketplace\r\n';
         for (const id of keys) {
             const r = stat.notInOpen[id];
-            content += `${positionOf(id, keys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): ${r.msVersion}\r\n`;
+            content += `${positionOf(id, keys)} ${generateLink(id)} (installs: ${humanNumber(r.msInstalls, formatter)}): ${r.msVersion}\r\n`;
         }
         content += '\r\n---\r\n';
     }
@@ -271,20 +269,20 @@ function generateLink = () => {
         content += '\r\n## Unstable (Open VSX > MS marketplace version)\r\n';
         for (const id of keys) {
             const r = stat.unstable[id];
-            content += `${positionOf(id, keys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.openVersion} > ${r.msVersion}\r\n`;
+            content += `${positionOf(id, keys)} ${generateLink(id)} (installs: ${humanNumber(r.msInstalls, formatter)}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.openVersion} > ${r.msVersion}\r\n`;
         }
         content += '\r\n---\r\n';
     }
 
     if (notInMS) {
         content += '\r\n## Not published to MS marketplace\r\n';
-        content += stat.notInMS.join(', ') + '\r\n';
+        content += stat.notInMS.map(ext => `- ${ext}`).join('\r\n');
         content += '\r\n---\r\n';
     }
 
     if (stat.failed.length) {
         content += '\r\n## Failed to publish\r\n';
-        content += stat.failed.join(', ') + '\r\n';
+        content += stat.failed.map(ext => `- ${generateLink(ext)}`).join('\r\n');
         content += '\r\n---\r\n';
     }
 
@@ -308,7 +306,7 @@ function generateLink = () => {
 
         for (const id of publishedKeys) {
             const r = stat.msPublished[id];
-            content += `${positionOf(id, publishedKeys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)})\r\n`;
+            content += `${positionOf(id, publishedKeys)} ${generateLink(id)} (installs: ${humanNumber(r.msInstalls, formatter)})\r\n`;
         }
 
         content += '\r\n---\r\n';
@@ -316,7 +314,7 @@ function generateLink = () => {
 
         for (const id of outdatedKeys) {
             const r = stat.msPublished[id];
-            content += `${positionOf(id, outdatedKeys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)})\r\n`;
+            content += `${positionOf(id, outdatedKeys)} ${generateLink(id)} (installs: ${humanNumber(r.msInstalls, formatter)})\r\n`;
         }
 
 
@@ -325,14 +323,14 @@ function generateLink = () => {
 
         for (const id of unstableKeys) {
             const r = stat.msPublished[id];
-            content += `${positionOf(id, unstableKeys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)})\r\n`;
+            content += `${positionOf(id, unstableKeys)} ${generateLink(id)} (installs: ${humanNumber(r.msInstalls, formatter)})\r\n`;
         }
 
         content += '\r\n---\r\n';
         content += '\r\n## MS missing from OpenVSX\r\n'
 
         for (const extension of couldPublishMs) {
-            content += `${positionOf(extension, couldPublishMs)} ${`${extension.publisher.publisherName}.${extension.extensionName}`} (installs: ${extension.statistics?.find(s => s.statisticName === 'install')?.value}})${definedInRepo.includes(`${extension.publisher.publisherName}.${extension.extensionName}`) ? ` [defined in extensions.json]` : ''}\r\n`;
+            content += `${positionOf(extension, couldPublishMs)} ${generateLink(`${extension.publisher.publisherName}.${extension.extensionName}`)} (installs: ${extension.statistics?.find(s => s.statisticName === 'install')?.value}})${definedInRepo.includes(`${extension.publisher.publisherName}.${extension.extensionName}`) ? ` [defined in extensions.json]` : ''}\r\n`;
         }
 
         content += '\r\n---\r\n';
@@ -346,7 +344,7 @@ function generateLink = () => {
             const in2Days = updatedInOpenIn2Days.has(id) ? '+' : '-';
             const in2Weeks = updatedInOpenIn2Weeks.has(id) ? '+' : '-';
             const inMonth = updatedInOpenInMonth.has(id) ? '+' : '-';
-            content += `${positionOf(id, keys)} ${inMonth}${in2Weeks}${in2Days} ${id}: installs: ${humanNumber(r.msInstalls, formatter)}; daysInBetween: ${r.daysInBetween?.toFixed(0)}; MS marketplace: ${r.msVersion}; Open VSX: ${r.openVersion}\r\n`;
+            content += `${positionOf(id, keys)} ${inMonth}${in2Weeks}${in2Days} ${generateLink(id)}: installs: ${humanNumber(r.msInstalls, formatter)}; daysInBetween: ${r.daysInBetween?.toFixed(0)}; MS marketplace: ${r.msVersion}; Open VSX: ${r.openVersion}\r\n`;
         }
         content += '\r\n---\r\n';
     }
@@ -356,7 +354,7 @@ function generateLink = () => {
         const keys = Object.keys(stat.upToDate).sort((a, b) => stat.upToDate[b].msInstalls - stat.upToDate[a].msInstalls);
         for (const id of keys) {
             const r = stat.upToDate[id];
-            content += `${positionOf(id, keys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.openVersion}\r\n`;
+            content += `${positionOf(id, keys)} ${generateLink(id)} (installs: ${humanNumber(r.msInstalls, formatter)}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.openVersion}\r\n`;
         }
         content += '\r\n---\r\n';
     }
@@ -366,24 +364,25 @@ function generateLink = () => {
         const keys = sortedKeys(stat.resolutions);
         for (const id of keys) {
             const r = stat.resolutions[id];
+            const base  = `${positionOf(id, keys)} ${generateLink(id)} (installs: ${humanNumber(r.msInstalls, formatter)}) from`;
             if (r?.releaseAsset) {
-                content += `${positionOf(id, keys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): from '${r.releaseAsset}' release asset\r\n`;
+                content += `${base} '${r.releaseAsset}' release asset\r\n`;
             } else if (r?.releaseTag) {
-                content += `${positionOf(id, keys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): from '${r.releaseTag}' release tag\r\n`;
+                content +=  `${base} '${r.releaseTag}' release tag\r\n`;
             } else if (r?.tag) {
-                content += `${positionOf(id, keys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): from '${r.tag}' release repo tag\r\n`;
+                content +=  `${base} from '${r.tag}' release repo tag\r\n`;
             } else if (r?.latest) {
                 if (r.msVersion) {
-                    content += `${positionOf(id, keys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): from '${r.latest}' the very latest repo commit, since it is not actively maintained\r\n`;
+                    content +=  `${base} from '${r.latest}' the very latest repo commit, since it is not actively maintained\r\n`;
                 } else {
-                    content += `${positionOf(id, keys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): from '${r.latest}' the very latest repo commit, since it is not published to MS marketplace\r\n`;
+                    content +=  `${base} from '${r.latest}' the very latest repo commit, since it is not published to MS marketplace\r\n`;
                 }
             } else if (r?.matchedLatest) {
-                content += `${positionOf(id, keys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): from '${r.matchedLatest}' from the very latest commit on the last update date\r\n`;
+                content +=  `${base} from '${r.matchedLatest}' from the very latest commit on the last update date\r\n`;
             } else if (r?.matched) {
-                content += `${positionOf(id, keys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): from '${r.matched}' from the latest commit on the last update date\r\n`;
+                content +=  `${base} from '${r.matched}' from the latest commit on the last update date\r\n`;
             } else {
-                content += `${positionOf(id, keys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): unresolved\r\n`;
+                content +=  `${base} unresolved\r\n`;
             }
         }
         content += '\r\n---\r\n';

--- a/report-extensions.js
+++ b/report-extensions.js
@@ -196,7 +196,7 @@ function streamToString(stream) {
 
     // Get missing extensions from Microsoft
 
-    let summary = '# Summary\r\n';
+    let summary = '# Summary\r\n\n';
     summary += `Total: ${total}\r\n`;
     summary += `Up-to-date (MS Marketplace == Open VSX): ${upToDate} (${(upToDate / total * 100).toFixed(0)}%) (${upToDateChange !== undefined ? `${upToDateChange ? `${Math.abs(upToDateChange).toFixed(3)}% ` : ''}${upToDateChange > 0 ? 'increase' : upToDateChange === 0 ? 'no change' : 'decrease'} since last week` : "WoW change n/a"})\r\n`;
     summary += `Weighted publish percentage: ${(weightedPercentage * 100).toFixed(0)}%\r\n`
@@ -205,11 +205,13 @@ function streamToString(stream) {
     summary += `Unstable (MS marketplace < Open VSX): ${unstable} (${(unstable / total * 100).toFixed(0)}%)\r\n`;
     summary += `Not in MS marketplace: ${notInMS} (${(notInMS / total * 100).toFixed(0)}%)\r\n`;
     summary += `Failed to publish: ${stat.failed.length} (${(stat.failed.length / total * 100).toFixed(0)}%) \r\n`;
+    summary += `\r\n\n`;
     summary += `Microsoft:\r\n`;
     summary += `Total: ${msPublished} (${(msPublished / total * 100).toFixed(0)}%)\r\n`;
     summary += `Outdated: ${msPublishedOutdated.length}\r\n`;
     summary += `Unstable: ${msPublishedUnstable.length}\r\n`;
     summary += `Missing: ${missingMs.length} (we could publish ${couldPublishMs.length} out of that)\r\n`
+    summary += `\r\n\n`;
     summary += `Total resolutions: ${totalResolutions}\r\n`;
     summary += `From release asset: ${fromReleaseAsset} (${(fromReleaseAsset / totalResolutions * 100).toFixed(0)}%)\r\n`;
     summary += `From release tag: ${fromReleaseTag} (${(fromReleaseTag / totalResolutions * 100).toFixed(0)}%)\r\n`;
@@ -219,13 +221,16 @@ function streamToString(stream) {
     summary += `From very latest repo commit on the last update date: ${fromMatchedLatest} (${(fromMatchedLatest / totalResolutions * 100).toFixed(0)}%)\r\n`;
     summary += `From latest repo commit on the last update date: ${fromMatched} (${(fromMatched / totalResolutions * 100).toFixed(0)}%)\r\n`;
     summary += `Total resolved: ${totalResolved} (${(totalResolved / totalResolutions * 100).toFixed(0)}%)\r\n`;
-    summary += `\r\n`;
+    summary += `\r\n\n`;
     summary += `Updated in MS marketplace in month-to-date: ${updatedInMTD}\r\n`;
     summary += `Of which updated in Open VSX within 2 days: ${updatedInOpenIn2Days.size} (${(updatedInOpenIn2Days.size / updatedInMTD * 100).toFixed(0)}%)\r\n`;
     summary += `Of which updated in Open VSX within 2 weeks: ${updatedInOpenIn2Weeks.size} (${(updatedInOpenIn2Weeks.size / updatedInMTD * 100).toFixed(0)}%)\r\n`;
     summary += `Of which updated in Open VSX within a month: ${updatedInOpenInMonth.size} (${(updatedInOpenInMonth.size / updatedInMTD * 100).toFixed(0)}%)\r\n`;
-    summary += '---\r\n';
+
     console.log(summary);
+    summary += `\r\n\n`;
+    summary += '---'
+    summary += `\r\n\n`;
 
     let content = summary;
     if (outdated) {

--- a/report-extensions.js
+++ b/report-extensions.js
@@ -45,6 +45,19 @@ function streamToString(stream) {
     })
 }
 
+/**
+ * @param {any} item
+ * @param {string | any[]} array
+ * @returns {string} the position of the item in the array with a `.` appended onto it.
+ */
+function positionOf(item, array) {
+    return `${array.indexOf(item) + 1}.`;
+}
+
+function generateLink = () => {
+    
+}
+
 (async () => {
 
     let lastWeekUpToDate;
@@ -238,7 +251,7 @@ function streamToString(stream) {
         content += '\r\n## Outdated (MS marketplace > Open VSX version)\r\n';
         for (const id of keys) {
             const r = stat.outdated[id];
-            content += `${keys.indexOf(id)}. ${id} (installs: ${humanNumber(r.msInstalls, formatter)}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.msVersion} > ${r.openVersion}\r\n`;
+            content += `${positionOf(id, keys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.msVersion} > ${r.openVersion}\r\n`;
         }
         content += '\r\n---\r\n';
     }
@@ -248,7 +261,7 @@ function streamToString(stream) {
         content += '\r\n## Not published to Open VSX, but in MS marketplace\r\n';
         for (const id of keys) {
             const r = stat.notInOpen[id];
-            content += `${id} (installs: ${humanNumber(r.msInstalls, formatter)}): ${r.msVersion}\r\n`;
+            content += `${positionOf(id, keys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): ${r.msVersion}\r\n`;
         }
         content += '\r\n---\r\n';
     }
@@ -258,7 +271,7 @@ function streamToString(stream) {
         content += '\r\n## Unstable (Open VSX > MS marketplace version)\r\n';
         for (const id of keys) {
             const r = stat.unstable[id];
-            content += `${keys.indexOf(id)}. ${id} (installs: ${humanNumber(r.msInstalls, formatter)}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.openVersion} > ${r.msVersion}\r\n`;
+            content += `${positionOf(id, keys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.openVersion} > ${r.msVersion}\r\n`;
         }
         content += '\r\n---\r\n';
     }
@@ -295,7 +308,7 @@ function streamToString(stream) {
 
         for (const id of publishedKeys) {
             const r = stat.msPublished[id];
-            content += `${publishedKeys.indexOf(id)}. ${id} (installs: ${humanNumber(r.msInstalls, formatter)})\r\n`;
+            content += `${positionOf(id, publishedKeys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)})\r\n`;
         }
 
         content += '\r\n---\r\n';
@@ -303,7 +316,7 @@ function streamToString(stream) {
 
         for (const id of outdatedKeys) {
             const r = stat.msPublished[id];
-            content += `${outdatedKeys.indexOf(id)}. ${id} (installs: ${humanNumber(r.msInstalls, formatter)})\r\n`;
+            content += `${positionOf(id, outdatedKeys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)})\r\n`;
         }
 
 
@@ -312,14 +325,14 @@ function streamToString(stream) {
 
         for (const id of unstableKeys) {
             const r = stat.msPublished[id];
-            content += `${unstableKeys.indexOf(id)}. ${id} (installs: ${humanNumber(r.msInstalls, formatter)})\r\n`;
+            content += `${positionOf(id, unstableKeys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)})\r\n`;
         }
 
         content += '\r\n---\r\n';
         content += '\r\n## MS missing from OpenVSX\r\n'
 
         for (const extension of couldPublishMs) {
-            content += `${couldPublishMs.indexOf(extension)}. ${`${extension.publisher.publisherName}.${extension.extensionName}`} (installs: ${extension.statistics?.find(s => s.statisticName === 'install')?.value}})${definedInRepo.includes(`${extension.publisher.publisherName}.${extension.extensionName}`) ? ` [defined in extensions.json]` : ''}\r\n`;
+            content += `${positionOf(extension, couldPublishMs)} ${`${extension.publisher.publisherName}.${extension.extensionName}`} (installs: ${extension.statistics?.find(s => s.statisticName === 'install')?.value}})${definedInRepo.includes(`${extension.publisher.publisherName}.${extension.extensionName}`) ? ` [defined in extensions.json]` : ''}\r\n`;
         }
 
         content += '\r\n---\r\n';
@@ -333,7 +346,7 @@ function streamToString(stream) {
             const in2Days = updatedInOpenIn2Days.has(id) ? '+' : '-';
             const in2Weeks = updatedInOpenIn2Weeks.has(id) ? '+' : '-';
             const inMonth = updatedInOpenInMonth.has(id) ? '+' : '-';
-            content += `${keys.indexOf(id)}. ${inMonth}${in2Weeks}${in2Days} ${id}: installs: ${humanNumber(r.msInstalls, formatter)}; daysInBetween: ${r.daysInBetween?.toFixed(0)}; MS marketplace: ${r.msVersion}; Open VSX: ${r.openVersion}\r\n`;
+            content += `${positionOf(id, keys)} ${inMonth}${in2Weeks}${in2Days} ${id}: installs: ${humanNumber(r.msInstalls, formatter)}; daysInBetween: ${r.daysInBetween?.toFixed(0)}; MS marketplace: ${r.msVersion}; Open VSX: ${r.openVersion}\r\n`;
         }
         content += '\r\n---\r\n';
     }
@@ -343,7 +356,7 @@ function streamToString(stream) {
         const keys = Object.keys(stat.upToDate).sort((a, b) => stat.upToDate[b].msInstalls - stat.upToDate[a].msInstalls);
         for (const id of keys) {
             const r = stat.upToDate[id];
-            content += `${keys.indexOf(id)}. ${id} (installs: ${humanNumber(r.msInstalls, formatter)}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.openVersion}\r\n`;
+            content += `${positionOf(id, keys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.openVersion}\r\n`;
         }
         content += '\r\n---\r\n';
     }
@@ -354,23 +367,23 @@ function streamToString(stream) {
         for (const id of keys) {
             const r = stat.resolutions[id];
             if (r?.releaseAsset) {
-                content += `${keys.indexOf(id)}. ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): from '${r.releaseAsset}' release asset\r\n`;
+                content += `${positionOf(id, keys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): from '${r.releaseAsset}' release asset\r\n`;
             } else if (r?.releaseTag) {
-                content += `${keys.indexOf(id)}. ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): from '${r.releaseTag}' release tag\r\n`;
+                content += `${positionOf(id, keys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): from '${r.releaseTag}' release tag\r\n`;
             } else if (r?.tag) {
-                content += `${keys.indexOf(id)}. ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): from '${r.tag}' release repo tag\r\n`;
+                content += `${positionOf(id, keys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): from '${r.tag}' release repo tag\r\n`;
             } else if (r?.latest) {
                 if (r.msVersion) {
-                    content += `${keys.indexOf(id)}. ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): from '${r.latest}' the very latest repo commit, since it is not actively maintained\r\n`;
+                    content += `${positionOf(id, keys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): from '${r.latest}' the very latest repo commit, since it is not actively maintained\r\n`;
                 } else {
-                    content += `${keys.indexOf(id)}. ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): from '${r.latest}' the very latest repo commit, since it is not published to MS marketplace\r\n`;
+                    content += `${positionOf(id, keys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): from '${r.latest}' the very latest repo commit, since it is not published to MS marketplace\r\n`;
                 }
             } else if (r?.matchedLatest) {
-                content += `${keys.indexOf(id)}. ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): from '${r.matchedLatest}' from the very latest commit on the last update date\r\n`;
+                content += `${positionOf(id, keys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): from '${r.matchedLatest}' from the very latest commit on the last update date\r\n`;
             } else if (r?.matched) {
-                content += `${keys.indexOf(id)}. ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): from '${r.matched}' from the latest commit on the last update date\r\n`;
+                content += `${positionOf(id, keys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): from '${r.matched}' from the latest commit on the last update date\r\n`;
             } else {
-                content += `${keys.indexOf(id)}. ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): unresolved\r\n`;
+                content += `${positionOf(id, keys)} ${id} (installs: ${humanNumber(r.msInstalls, formatter)}): unresolved\r\n`;
             }
         }
         content += '\r\n---\r\n';

--- a/report-extensions.js
+++ b/report-extensions.js
@@ -196,7 +196,7 @@ function streamToString(stream) {
 
     // Get missing extensions from Microsoft
 
-    let summary = '----- Summary -----\r\n';
+    let summary = '# Summary\r\n';
     summary += `Total: ${total}\r\n`;
     summary += `Up-to-date (MS Marketplace == Open VSX): ${upToDate} (${(upToDate / total * 100).toFixed(0)}%) (${upToDateChange !== undefined ? `${upToDateChange ? `${Math.abs(upToDateChange).toFixed(3)}% ` : ''}${upToDateChange > 0 ? 'increase' : upToDateChange === 0 ? 'no change' : 'decrease'} since last week` : "WoW change n/a"})\r\n`;
     summary += `Weighted publish percentage: ${(weightedPercentage * 100).toFixed(0)}%\r\n`
@@ -224,47 +224,47 @@ function streamToString(stream) {
     summary += `Of which updated in Open VSX within 2 days: ${updatedInOpenIn2Days.size} (${(updatedInOpenIn2Days.size / updatedInMTD * 100).toFixed(0)}%)\r\n`;
     summary += `Of which updated in Open VSX within 2 weeks: ${updatedInOpenIn2Weeks.size} (${(updatedInOpenIn2Weeks.size / updatedInMTD * 100).toFixed(0)}%)\r\n`;
     summary += `Of which updated in Open VSX within a month: ${updatedInOpenInMonth.size} (${(updatedInOpenInMonth.size / updatedInMTD * 100).toFixed(0)}%)\r\n`;
-    summary += '-------------------\r\n';
+    summary += '---\r\n';
     console.log(summary);
 
     let content = summary;
     if (outdated) {
-        content += '\r\n----- Outdated (MS marketplace > Open VSX version) -----\r\n';
+        content += '\r\n## Outdated (MS marketplace > Open VSX version)\r\n';
         for (const id of sortedKeys(stat.outdated)) {
             const r = stat.outdated[id];
             content += `${id} (installs: ${humanNumber(r.msInstalls, formatter)}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.msVersion} > ${r.openVersion}\r\n`;
         }
-        content += '-------------------\r\n';
+        content += '---\r\n';
     }
 
     if (notInOpen) {
-        content += '\r\n----- Not published to Open VSX, but in MS marketplace -----\r\n';
+        content += '\r\n## Not published to Open VSX, but in MS marketplace\r\n';
         for (const id of Object.keys(stat.notInOpen).sort((a, b) => stat.notInOpen[b].msInstalls - stat.notInOpen[a].msInstalls)) {
             const r = stat.notInOpen[id];
             content += `${id} (installs: ${humanNumber(r.msInstalls, formatter)}): ${r.msVersion}\r\n`;
         }
-        content += '-------------------\r\n';
+        content += '---\r\n';
     }
 
     if (unstable) {
-        content += '\r\n----- Unstable (Open VSX > MS marketplace version) -----\r\n';
+        content += '\r\n## Unstable (Open VSX > MS marketplace version)\r\n';
         for (const id of sortedKeys(stat.unstable)) {
             const r = stat.unstable[id];
             content += `${id} (installs: ${humanNumber(r.msInstalls, formatter)}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.openVersion} > ${r.msVersion}\r\n`;
         }
-        content += '-------------------\r\n';
+        content += '---\r\n';
     }
 
     if (notInMS) {
-        content += '\r\n----- Not published to MS marketplace -----\r\n';
+        content += '\r\n## Not published to MS marketplace\r\n';
         content += stat.notInMS.join(', ') + '\r\n';
-        content += '-------------------\r\n';
+        content += '---\r\n';
     }
 
     if (stat.failed.length) {
-        content += '\r\n----- Failed to publish -----\r\n';
+        content += '\r\n## Failed to publish\r\n';
         content += stat.failed.join(', ') + '\r\n';
-        content += '-------------------\r\n';
+        content += '---\r\n';
     }
 
     if ((unstable || stat.failed.length || outdated) && process.env.VALIDATE_PR === 'true') {
@@ -272,20 +272,20 @@ function streamToString(stream) {
         process.exitCode = -1;
     }
 
-    if (yesterdayWeightedPercentage > (weightedPercentage * 1.05)) {
+    if (yesterdayWeightedPercentage && yesterdayWeightedPercentage > (weightedPercentage * 1.05)) {
         // This should indicate a big extension breaking
         process.exitCode = -1;
     }
 
     if (msPublished) {
-        content += '\r\n----- MS extensions -----\r\n'
+        content += '\r\n## MS extensions\r\n'
         for (const id of Object.keys(stat.msPublished).sort((a, b) => stat.msPublished[b].msInstalls - stat.msPublished[a].msInstalls)) {
             const r = stat.msPublished[id];
             content += `${id} (installs: ${humanNumber(r.msInstalls, formatter)})\r\n`;
         }
 
-        content += '-------------------\r\n';
-        content += '\r\n----- MS Outdated -----\r\n'
+        content += '---\r\n';
+        content += '\r\n## MS Outdated\r\n'
 
         for (const id of msPublishedOutdated.sort((a, b) => stat.msPublished[b].msInstalls - stat.msPublished[a].msInstalls)) {
             const r = stat.msPublished[id];
@@ -293,26 +293,26 @@ function streamToString(stream) {
         }
 
 
-        content += '-------------------\r\n';
-        content += '\r\n----- MS Unstable -----\r\n'
+        content += '---\r\n';
+        content += '\r\n## MS Unstable\r\n'
 
         for (const id of msPublishedUnstable.sort((a, b) => stat.msPublished[b].msInstalls - stat.msPublished[a].msInstalls)) {
             const r = stat.msPublished[id];
             content += `${id} (installs: ${humanNumber(r.msInstalls, formatter)})\r\n`;
         }
 
-        content += '-------------------\r\n';
-        content += '\r\n----- MS missing from OpenVSX -----\r\n'
+        content += '---\r\n';
+        content += '\r\n## MS missing from OpenVSX\r\n'
 
         for (const extension of couldPublishMs) {
             content += `${`${extension.publisher.publisherName}.${extension.extensionName}`} (installs: ${extension.statistics?.find(s => s.statisticName === 'install')?.value}})${definedInRepo.includes(`${extension.publisher.publisherName}.${extension.extensionName}`) ? ` [defined in extensions.json]` : ''}\r\n`;
         }
 
-        content += '-------------------\r\n';
+        content += '---\r\n';
     }
 
     if (updatedInMTD) {
-        content += '\r\n----- Updated in Open VSX within 2 days after in MS marketplace in MTD -----\r\n';
+        content += '\r\n## Updated in Open VSX within 2 days after in MS marketplace in MTD\r\n';
         for (const id of sortedKeys(stat.hitMiss)) {
             const r = stat.hitMiss[id];
             const in2Days = updatedInOpenIn2Days.has(id) ? '+' : '-';
@@ -320,20 +320,20 @@ function streamToString(stream) {
             const inMonth = updatedInOpenInMonth.has(id) ? '+' : '-';
             content += `${inMonth}${in2Weeks}${in2Days} ${id}: installs: ${humanNumber(r.msInstalls, formatter)}; daysInBetween: ${r.daysInBetween?.toFixed(0)}; MS marketplace: ${r.msVersion}; Open VSX: ${r.openVersion}\r\n`;
         }
-        content += '-------------------\r\n';
+        content += '---\r\n';
     }
 
     if (upToDate) {
-        content += '\r\n----- Up-to-date (Open VSX = MS marketplace version) -----\r\n';
+        content += '\r\n## Up-to-date (Open VSX = MS marketplace version)\r\n';
         for (const id of Object.keys(stat.upToDate).sort((a, b) => stat.upToDate[b].msInstalls - stat.upToDate[a].msInstalls)) {
             const r = stat.upToDate[id];
             content += `${id} (installs: ${humanNumber(r.msInstalls, formatter)}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.openVersion}\r\n`;
         }
-        content += '-------------------\r\n';
+        content += '---\r\n';
     }
 
     if (totalResolutions) {
-        content += '\r\n----- Resolutions -----\r\n';
+        content += '\r\n## Resolutions\r\n';
         for (const id of sortedKeys(stat.resolutions)) {
             const r = stat.resolutions[id];
             if (r?.releaseAsset) {
@@ -356,10 +356,10 @@ function streamToString(stream) {
                 content += `${id} (installs: ${humanNumber(r.msInstalls, formatter)}): unresolved\r\n`;
             }
         }
-        content += '-------------------\r\n';
+        content += '---\r\n';
     }
 
-    await fs.promises.writeFile("/tmp/result.log", content, { encoding: 'utf8' });
+    await fs.promises.writeFile("/tmp/result.md", content, { encoding: 'utf8' });
     const metadata = {
         weightedPercentage
     };

--- a/report-extensions.js
+++ b/report-extensions.js
@@ -251,7 +251,6 @@ const generateLink = (/** @type {string} */ id) =>  `[${id}](https://marketplace
             const r = stat.outdated[id];
             content += `${positionOf(id, keys)} ${generateLink(id)} (installs: ${humanNumber(r.msInstalls, formatter)}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.msVersion} > ${r.openVersion}\r\n`;
         }
-        content += '\r\n---\r\n';
     }
 
     if (notInOpen) {
@@ -261,7 +260,6 @@ const generateLink = (/** @type {string} */ id) =>  `[${id}](https://marketplace
             const r = stat.notInOpen[id];
             content += `${positionOf(id, keys)} ${generateLink(id)} (installs: ${humanNumber(r.msInstalls, formatter)}): ${r.msVersion}\r\n`;
         }
-        content += '\r\n---\r\n';
     }
 
     if (unstable) {
@@ -271,19 +269,18 @@ const generateLink = (/** @type {string} */ id) =>  `[${id}](https://marketplace
             const r = stat.unstable[id];
             content += `${positionOf(id, keys)} ${generateLink(id)} (installs: ${humanNumber(r.msInstalls, formatter)}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.openVersion} > ${r.msVersion}\r\n`;
         }
-        content += '\r\n---\r\n';
     }
 
     if (notInMS) {
         content += '\r\n## Not published to MS marketplace\r\n';
         content += stat.notInMS.map(ext => `- ${ext}`).join('\r\n');
-        content += '\r\n---\r\n';
+        content += '\r\n';
     }
 
     if (stat.failed.length) {
         content += '\r\n## Failed to publish\r\n';
         content += stat.failed.map(ext => `- ${generateLink(ext)}`).join('\r\n');
-        content += '\r\n---\r\n';
+        content += '\r\n';
     }
 
     if ((unstable || stat.failed.length || outdated) && process.env.VALIDATE_PR === 'true') {
@@ -309,7 +306,6 @@ const generateLink = (/** @type {string} */ id) =>  `[${id}](https://marketplace
             content += `${positionOf(id, publishedKeys)} ${generateLink(id)} (installs: ${humanNumber(r.msInstalls, formatter)})\r\n`;
         }
 
-        content += '\r\n---\r\n';
         content += '\r\n## MS Outdated\r\n'
 
         for (const id of outdatedKeys) {
@@ -318,7 +314,6 @@ const generateLink = (/** @type {string} */ id) =>  `[${id}](https://marketplace
         }
 
 
-        content += '\r\n---\r\n';
         content += '\r\n## MS Unstable\r\n'
 
         for (const id of unstableKeys) {
@@ -326,14 +321,11 @@ const generateLink = (/** @type {string} */ id) =>  `[${id}](https://marketplace
             content += `${positionOf(id, unstableKeys)} ${generateLink(id)} (installs: ${humanNumber(r.msInstalls, formatter)})\r\n`;
         }
 
-        content += '\r\n---\r\n';
         content += '\r\n## MS missing from OpenVSX\r\n'
 
         for (const extension of couldPublishMs) {
             content += `${positionOf(extension, couldPublishMs)} ${generateLink(`${extension.publisher.publisherName}.${extension.extensionName}`)} (installs: ${extension.statistics?.find(s => s.statisticName === 'install')?.value}})${definedInRepo.includes(`${extension.publisher.publisherName}.${extension.extensionName}`) ? ` [defined in extensions.json]` : ''}\r\n`;
         }
-
-        content += '\r\n---\r\n';
     }
 
     if (updatedInMTD) {
@@ -346,7 +338,7 @@ const generateLink = (/** @type {string} */ id) =>  `[${id}](https://marketplace
             const inMonth = updatedInOpenInMonth.has(id) ? '+' : '-';
             content += `${positionOf(id, keys)} ${inMonth}${in2Weeks}${in2Days} ${generateLink(id)}: installs: ${humanNumber(r.msInstalls, formatter)}; daysInBetween: ${r.daysInBetween?.toFixed(0)}; MS marketplace: ${r.msVersion}; Open VSX: ${r.openVersion}\r\n`;
         }
-        content += '\r\n---\r\n';
+        content += '\r\n';
     }
 
     if (upToDate) {
@@ -356,7 +348,7 @@ const generateLink = (/** @type {string} */ id) =>  `[${id}](https://marketplace
             const r = stat.upToDate[id];
             content += `${positionOf(id, keys)} ${generateLink(id)} (installs: ${humanNumber(r.msInstalls, formatter)}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.openVersion}\r\n`;
         }
-        content += '\r\n---\r\n';
+        content += '\r\n';
     }
 
     if (totalResolutions) {
@@ -385,7 +377,6 @@ const generateLink = (/** @type {string} */ id) =>  `[${id}](https://marketplace
                 content +=  `${base} unresolved\r\n`;
             }
         }
-        content += '\r\n---\r\n';
     }
 
     await fs.promises.writeFile("/tmp/result.md", content, { encoding: 'utf8' });

--- a/report-extensions.js
+++ b/report-extensions.js
@@ -239,7 +239,7 @@ function streamToString(stream) {
             const r = stat.outdated[id];
             content += `${id} (installs: ${humanNumber(r.msInstalls, formatter)}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.msVersion} > ${r.openVersion}\r\n`;
         }
-        content += '---\r\n';
+        content += '\r\n---\r\n';
     }
 
     if (notInOpen) {
@@ -248,7 +248,7 @@ function streamToString(stream) {
             const r = stat.notInOpen[id];
             content += `${id} (installs: ${humanNumber(r.msInstalls, formatter)}): ${r.msVersion}\r\n`;
         }
-        content += '---\r\n';
+        content += '\r\n---\r\n';
     }
 
     if (unstable) {
@@ -257,19 +257,19 @@ function streamToString(stream) {
             const r = stat.unstable[id];
             content += `${id} (installs: ${humanNumber(r.msInstalls, formatter)}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.openVersion} > ${r.msVersion}\r\n`;
         }
-        content += '---\r\n';
+        content += '\r\n---\r\n';
     }
 
     if (notInMS) {
         content += '\r\n## Not published to MS marketplace\r\n';
         content += stat.notInMS.join(', ') + '\r\n';
-        content += '---\r\n';
+        content += '\r\n---\r\n';
     }
 
     if (stat.failed.length) {
         content += '\r\n## Failed to publish\r\n';
         content += stat.failed.join(', ') + '\r\n';
-        content += '---\r\n';
+        content += '\r\n---\r\n';
     }
 
     if ((unstable || stat.failed.length || outdated) && process.env.VALIDATE_PR === 'true') {
@@ -289,7 +289,7 @@ function streamToString(stream) {
             content += `${id} (installs: ${humanNumber(r.msInstalls, formatter)})\r\n`;
         }
 
-        content += '---\r\n';
+        content += '\r\n---\r\n';
         content += '\r\n## MS Outdated\r\n'
 
         for (const id of msPublishedOutdated.sort((a, b) => stat.msPublished[b].msInstalls - stat.msPublished[a].msInstalls)) {
@@ -298,7 +298,7 @@ function streamToString(stream) {
         }
 
 
-        content += '---\r\n';
+        content += '\r\n---\r\n';
         content += '\r\n## MS Unstable\r\n'
 
         for (const id of msPublishedUnstable.sort((a, b) => stat.msPublished[b].msInstalls - stat.msPublished[a].msInstalls)) {
@@ -306,14 +306,14 @@ function streamToString(stream) {
             content += `${id} (installs: ${humanNumber(r.msInstalls, formatter)})\r\n`;
         }
 
-        content += '---\r\n';
+        content += '\r\n---\r\n';
         content += '\r\n## MS missing from OpenVSX\r\n'
 
         for (const extension of couldPublishMs) {
             content += `${`${extension.publisher.publisherName}.${extension.extensionName}`} (installs: ${extension.statistics?.find(s => s.statisticName === 'install')?.value}})${definedInRepo.includes(`${extension.publisher.publisherName}.${extension.extensionName}`) ? ` [defined in extensions.json]` : ''}\r\n`;
         }
 
-        content += '---\r\n';
+        content += '\r\n---\r\n';
     }
 
     if (updatedInMTD) {
@@ -325,7 +325,7 @@ function streamToString(stream) {
             const inMonth = updatedInOpenInMonth.has(id) ? '+' : '-';
             content += `${inMonth}${in2Weeks}${in2Days} ${id}: installs: ${humanNumber(r.msInstalls, formatter)}; daysInBetween: ${r.daysInBetween?.toFixed(0)}; MS marketplace: ${r.msVersion}; Open VSX: ${r.openVersion}\r\n`;
         }
-        content += '---\r\n';
+        content += '\r\n---\r\n';
     }
 
     if (upToDate) {
@@ -334,7 +334,7 @@ function streamToString(stream) {
             const r = stat.upToDate[id];
             content += `${id} (installs: ${humanNumber(r.msInstalls, formatter)}, daysInBetween: ${r.daysInBetween.toFixed(0)}): ${r.openVersion}\r\n`;
         }
-        content += '---\r\n';
+        content += '\r\n---\r\n';
     }
 
     if (totalResolutions) {
@@ -361,7 +361,7 @@ function streamToString(stream) {
                 content += `${id} (installs: ${humanNumber(r.msInstalls, formatter)}): unresolved\r\n`;
             }
         }
-        content += '---\r\n';
+        content += '\r\n---\r\n';
     }
 
     await fs.promises.writeFile("/tmp/result.md", content, { encoding: 'utf8' });


### PR DESCRIPTION
Replace `.log` with `.md`.

You can see the new [GitHub Job summary](https://github.blog/changelog/2022-05-09-github-actions-enhance-your-actions-with-job-summaries/) in action (pun not intended) in the latest Action's summary page: https://github.com/open-vsx/publish-extensions/actions/runs/2537932529#summary-6992131746. 