### PR TITLE
Add pbkit.vscode-pbkit.

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1013,6 +1013,10 @@
   "paulmolluzzo.convert-css-in-js": {
     "repository": "https://github.com/paulmolluzzo/convert-css-in-js"
   },
+  "pbkit.vscode-pbkit": {
+    "repository": "https://github.com/pbkit/vscode-pbkit",
+    "prepublish": "npm run build"
+  },
   "peterj.proto": {
     "repository": "https://github.com/pj3677/vscode-protobuf",
     "prepublish": "[ $VERSION = '0.0.3' ] && sed -i 's/\\(\"icon\": \".*\\.\\)svg\\(\"\\)/\\1png\\2/g' package.json && npx svgexport ./images/protobuficon.svg ./images/protobuficon.png || true"


### PR DESCRIPTION
- [x] I have read the note above about PRs contributing or fixing extensions
- [x] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX: https://github.com/pbkit/vscode-pbkit/issues/19
- [x] This extension has MIT license.

## Description

Add `pbkit.vscode-pbkit` - a VSCode extension for Protobuf. Syntax highlight, goto definition and autocompletion.