### PR TITLE
feat: add ms-python.black-formatter

### DIFF
--- a/.github/workflows/publish-extensions.yml
+++ b/.github/workflows/publish-extensions.yml
@@ -36,7 +36,7 @@ jobs:
           node-version: "14.x"
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.7"
       - uses: actions/setup-java@v3
         with:
           distribution: "microsoft"

--- a/extensions.json
+++ b/extensions.json
@@ -754,6 +754,9 @@
     "location": "packages/vscode-pyright",
     "prepublish": "npm i && cd packages/vscode-pyright && npm run prepackage"
   },
+  "ms-python.black-formatter": {
+    "repository": "https://github.com/microsoft/vscode-black-formatter"
+  },
   "ms-python.python": {
     "repository": "https://github.com/microsoft/vscode-python",
     "prepublish": "PIP_USER=no python3 -m pip --disable-pip-version-check install -r build/debugger-install-requirements.txt && python3 ./pythonFiles/install_debugpy.py && python3 -m pip install --no-deps --require-hashes --only-binary :all: -t ./pythonFiles/lib/python --implementation py -r ./requirements.txt && python3 -m pip install --no-deps --require-hashes --only-binary :all: -t ./pythonFiles/lib/jedilsp --implementation py --platform any --abi none -r ./pythonFiles/jedilsp_requirements/requirements.txt && python3 ./build/update_ext_version.py --release --for-publishing && npm run addExtensionPackDependencies && DISABLE_TRANSLATIONS=true npm run package",

--- a/extensions.json
+++ b/extensions.json
@@ -755,7 +755,16 @@
     "prepublish": "npm i && cd packages/vscode-pyright && npm run prepackage"
   },
   "ms-python.black-formatter": {
-    "repository": "https://github.com/microsoft/vscode-black-formatter"
+    "repository": "https://github.com/microsoft/vscode-black-formatter",
+    "custom": [
+      "python -m pip install -U pip",
+      "python -m pip install wheel",
+      "python -m pip install nox",
+      "npm ci --prefer-offline",
+      "python -m nox --session install_bundled_libs",
+      "npm run vsce-package"
+    ],
+    "extensionFile": "black-formatter.vsix"
   },
   "ms-python.python": {
     "repository": "https://github.com/microsoft/vscode-python",


### PR DESCRIPTION
<!--

### For extension authors

`publish-extensions` exists to seed the Open VSX marketplace, and also serves as a place for extensions that cannot feasibly be published directly by the extensions authors. In the long-run it is better for extension owners to publish their own plugins because:

1. Any future issues (features/bugs) with any published extensions in Open VSX will be directed to their original repo/source-control, and not confused with this repo publish-extensions.
2. Extensions published by official authors are shown within the Open VSX marketplace as such. Whereas extensions published via publish-extensions display a warning that the publisher (this repository) is not the official author.
3. Extension owners who publish their own extensions get greater flexibility on the publishing/release process, therefore ensure more accuracy/stability. For instance, in some cases publish-extensions has build steps within this repository, which can cause some uploaded plugin versions to break (e.g. if a plugin build step changes).

If you are the author of the extension being raised in this PR, please first consider directly publishing the extension yourself. You can refer to our [direct publish setup](docs/direct_publish_setup.md) doc for a guide on how to publish your plugin to Open VSX.

### For community contributors

For the sake of efficiency and simplicity, the easiest way to publish an extension is by having it published by its maintainers, for more info about this please refer to the [README](https://github.com/open-vsx/publish-extensions#when-to-add-an-extension). If the authors are open to publish the extension to Open VSX, you can help them by contributing a GitHub Action using our handy-dandy [direct publish setup](docs/direct_publish_setup.md) doc.

 - If the extension is unmaintained, please create an issue for it instead.

For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

-->

- [x] I have read the note above about PRs contributing or fixing extensions
- [ ] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).
- [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description

<!-- Please do not leave this blank -->

According to https://github.com/microsoft/vscode-python/issues/1883#issuecomment-1252998902,  [Black](https://black.readthedocs.io/en/stable/) support will start moving out from `ms-python.python` into this new extension.
