### PR TITLE
Add `rioj7/command-variable`

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1118,6 +1118,10 @@
   "richie5um2.vscode-sort-json": {
     "repository": "https://github.com/richie5um/vscode-sort-json"
   },
+  "rioj7.command-variable": {
+    "repository": "https://github.com/rioj7/command-variable",
+    "prepublish": "npm run build"
+  },
   "rioj7.FileGroup": {
     "repository": "https://github.com/rioj7/fileGroup"
   },


### PR DESCRIPTION
## Description

This PR introduces `rioj7/command-variable` for publishing on open-vsx.

Relates to rioj7/command-variable#44
