### PR TITLE
Add BriteSnow/vscode-toggle-quotes

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -136,6 +136,9 @@
   "bradlc.vscode-tailwindcss": {
     "repository": "https://github.com/tailwindlabs/tailwindcss-intellisense"
   },
+  "BriteSnow.vscode-toggle-quotes": {
+    "repository": "https://github.com/BriteSnow/vscode-toggle-quotes"
+  },
   "buianhthang.gitflow": {
     "repository": "https://github.com/anhthang/vscode-gitflow"
   },


### PR DESCRIPTION
- [X] I have read the note above about PRs contributing or fixing extensions
- [X] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).
- [X] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description

This PR adds the [BriteSnow/vscode-toggle-quotes](https://github.com/BriteSnow/vscode-toggle-quotes) extension to the marketplace. The maintainer hasn't had time to add it and said I should feel free to make a PR.

cc @jeremychone