### PR TITLE
Added `sswig.swift-lang`

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1253,6 +1253,9 @@
   "sorbet.sorbet-vscode-extension": {
     "repository": "https://github.com/sorbet/sorbet"
   },
+  "sswg.swift-lang": {
+    "repository": "https://github.com/swift-server/vscode-swift"
+  },
   "steoates.autoimport": {
     "repository": "https://github.com/soates/Auto-Import"
   },


### PR DESCRIPTION
This is intended to add vscode-swift to the OpenVSX repository.  An issue at the original extension repo has been open since Dec 24, 2021.  This seems to be stuck in Apple legal purgatory.

https://github.com/swift-server/vscode-swift/issues/90

Thanks!