### PR TITLE
add MS-SarifVSCode.sarif-viewer

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -870,6 +870,9 @@
     "pythonVersion": "3.8",
     "timeout": 30
   },
+  "MS-SarifVSCode.sarif-viewer": {
+    "repository": "https://github.com/Microsoft/sarif-vscode-extension"
+  },
   "ms-toolsai.jupyter": {
     "repository": "https://github.com/microsoft/vscode-jupyter",
     "custom": [


### PR DESCRIPTION
- [x] I have read the note above about PRs contributing or fixing extensions
- [x] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).
- [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description

- This will add [this extension](https://github.com/microsoft/sarif-vscode-extension) (MS-SarifVSCode.sarif-viewer)
- I have opened [an issue upstream](https://github.com/microsoft/sarif-vscode-extension/issues/547) but since it's MS I don't expect them to publish it on Open VSX
- It's a MIT license so OSI approved
- I have followed the steps [here](https://github.com/open-vsx/publish-extensions/blob/master/DEVELOPMENT.md#publishing-options) to build and test and have installed the extension successfully on Code OSS.
