### PR TITLE
Added chrisdias.vscode-opennewinstance

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -157,6 +157,13 @@
   "cheshirekow.cmake-format": {
     "repository": "https://github.com/cheshirekow/cmake_format"
   },
+  "chrisdias.vscode-opennewinstance": {
+    "repository": "https://github.com/chrisdias/vscode-opennewinstance",
+    "custom": [
+      "NODE_OPTIONS=--openssl-legacy-provider npm install",
+      "NODE_OPTIONS=--openssl-legacy-provider vsce package -o extension.vsix --baseContentUrl https://github.com/chrisdias/vscode-opennewinstance/blob/HEAD --baseImagesUrl https://github.com/chrisdias/vscode-opennewinstance/raw/HEAD"
+    ]
+  },
   "christianvoigt.argdown-vscode": {
     "repository": "https://github.com/christianvoigt/argdown",
     "location": "packages/argdown-vscode",


### PR DESCRIPTION
<!--

### For community contributors

For the sake of efficiency and simplicity, the easiest way to publish an extension is by having it published by its maintainers, for more info about this please refer to the [README](https://github.com/open-vsx/publish-extensions#when-to-add-an-extension). If the authors are open to publish the extension to Open VSX, you can help them by contributing a GitHub Action using our handy-dandy [direct publish setup](docs/direct_publish_setup.md) doc.

 - If the extension is unmaintained, please create an issue for it instead.

For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

-->

-   [x] I have read the note above about PRs contributing or fixing extensions
-   [x] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).
-   [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description

This PR introduces add the `chrisdias.vscode-opennewinstance` package.

- Request for the author to add: https://github.com/chrisdias/vscode-opennewinstance/issues/21
- MIT license: https://github.com/chrisdias/vscode-opennewinstance/blob/master/LICENSE.md

I tested by running the following:

```bash
GITHUB_TOKEN=xxxx EXTENSIONS=chrisdias.vscode-opennewinstance SKIP_PUBLISH=true node publish-extensions.js
```