### PR TITLE
Add `ms-vscode.wasm-wasi-core` and `ms-vscode.webshell`

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1055,13 +1055,13 @@
     "location": "wasm-wasi-core",
     "custom": [
       "cd wasm-wasi-core && jq '.scripts[\"update:version\"] = \"\"' package.json > tmp.json && mv tmp.json package.json",
-      "cd wasm-wasi-core && vsce package -o extension.vsix"
+      "cd wasm-wasi-core && npm i && vsce package -o extension.vsix"
     ]
   },
   "ms-vscode.webshell": {
     "repository": "https://github.com/microsoft/vscode-wasm.git",
     "location": "webshell",
-    "custom": ["cd webshell && vsce package -o extension.vsix"]
+    "custom": ["cd webshell && npm i && vsce package -o extension.vsix"]
   },
   "msjsdiag.debugger-for-edge": {
     "repository": "https://github.com/Microsoft/vscode-edge-debug2"

--- a/extensions.json
+++ b/extensions.json
@@ -1055,13 +1055,13 @@
     "location": "wasm-wasi-core",
     "custom": [
       "cd wasm-wasi-core && jq '.scripts[\"update:version\"] = \"\"' package.json > tmp.json && mv tmp.json package.json",
-      "cd wasm-wasi-core && npm i && vsce package -o extension.vsix"
+      "npm i && cd wasm-wasi-core && vsce package -o extension.vsix"
     ]
   },
   "ms-vscode.webshell": {
     "repository": "https://github.com/microsoft/vscode-wasm.git",
     "location": "webshell",
-    "custom": ["cd webshell && npm i && vsce package -o extension.vsix"]
+    "custom": ["npm i && cd webshell && vsce package -o extension.vsix"]
   },
   "msjsdiag.debugger-for-edge": {
     "repository": "https://github.com/Microsoft/vscode-edge-debug2"

--- a/extensions.json
+++ b/extensions.json
@@ -1050,6 +1050,14 @@
   "ms-vscode.vscode-typescript-next": {
     "repository": "https://github.com/microsoft/vscode-typescript-next.git"
   },
+  "ms-vscode.wasm-wasi-core": {
+    "repository": "https://github.com/microsoft/vscode-wasm.git",
+    "location": "wasm-wasi-core"
+  },
+  "ms-vscode.webshell": {
+    "repository": "https://github.com/microsoft/vscode-wasm.git",
+    "location": "webshell"
+  },
   "msjsdiag.debugger-for-edge": {
     "repository": "https://github.com/Microsoft/vscode-edge-debug2"
   },

--- a/extensions.json
+++ b/extensions.json
@@ -1052,11 +1052,16 @@
   },
   "ms-vscode.wasm-wasi-core": {
     "repository": "https://github.com/microsoft/vscode-wasm.git",
-    "location": "wasm-wasi-core"
+    "location": "wasm-wasi-core",
+    "custom": [
+      "cd wasm-wasi-core && jq '.scripts[\"update:version\"] = \"\"' package.json > tmp.json && mv tmp.json package.json",
+      "cd wasm-wasi-core && vsce package -o extension.vsix"
+    ]
   },
   "ms-vscode.webshell": {
     "repository": "https://github.com/microsoft/vscode-wasm.git",
-    "location": "webshell"
+    "location": "webshell",
+    "custom": ["cd webshell && vsce package -o extension.vsix"]
   },
   "msjsdiag.debugger-for-edge": {
     "repository": "https://github.com/Microsoft/vscode-edge-debug2"


### PR DESCRIPTION
-   [x] I have read the note above about PRs contributing or fixing extensions
-   [x] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).
-   [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description

This PR adds `ms-vscode.wasm-wasi-core` and `ms-vscode.webshell` extensions.

Request for the author to add: https://github.com/microsoft/vscode-wasm/issues/152, same situation as with vscode-eslint extension: https://github.com/microsoft/vscode-eslint/issues/1842#issuecomment-2095506576
MIT license: https://github.com/microsoft/vscode-wasm/blob/main/LICENSE

