### PR TITLE
Manually Update SilverStripe Extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -15,7 +15,7 @@
   "adrianhumphreys.silverstripe": {
     "repository": "https://github.com/adrhumphreys/vscode-silverstripe",
     "custom": [
-      "git reset --hard a3fd311cdabdca6a23a3d5cc18c2bc00b7f16c2c",
+      "git checkout a3fd311cdabdca6a23a3d5cc18c2bc00b7f16c2c",
       "jq '.version = \"1.0.6\"' package.json > tmp.json && mv tmp.json package.json",
       "npm install",
       "NODE_OPTIONS=--openssl-legacy-provider vsce package -o extension.vsix"

--- a/extensions.json
+++ b/extensions.json
@@ -15,6 +15,8 @@
   "adrianhumphreys.silverstripe": {
     "repository": "https://github.com/adrhumphreys/vscode-silverstripe",
     "custom": [
+      "git reset --hard a3fd311cdabdca6a23a3d5cc18c2bc00b7f16c2c",
+      "jq '.version = \"1.0.6\"' package.json > tmp.json && mv tmp.json package.json",
       "npm install",
       "NODE_OPTIONS=--openssl-legacy-provider vsce package -o extension.vsix"
     ]

--- a/extensions.json
+++ b/extensions.json
@@ -13,7 +13,11 @@
     "repository": "https://github.com/kufii/CodeSnap"
   },
   "adrianhumphreys.silverstripe": {
-    "repository": "https://github.com/adrhumphreys/vscode-silverstripe"
+    "repository": "https://github.com/adrhumphreys/vscode-silverstripe",
+    "custom": [
+      "npm install",
+      "NODE_OPTIONS=--openssl-legacy-provider vsce package -o extension.vsix"
+    ]
   },
   "adrieankhisbe.vscode-ndjson": {
     "repository": "https://github.com/AdrieanKhisbe/vscode-ndjson"


### PR DESCRIPTION
-   [x] I have read the note above about PRs contributing or fixing extensions
-   [ ] ~~I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).~~
-   [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description
As described in #767, the SilverStripe extension is unmaintained and hints the incorrect version number in its `package.json` file. Furthermore, the current `.vsix` file hosted on Open-VSX is broken and doesn't work properly - even causing other extensions to not getting loaded.

Therefore, changes made in this PR will:
  - Check out the (at time of writing) most recent commit
  - Set the (at time of writing) most recent version number in the `package.json` file
  - Apart from that publish it normally

Merging this PR will close #767