### PR TITLE
Release debugpy on macOS intel

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -832,6 +832,11 @@
           "VSCETARGET": "darwin-arm64"
         }
       },
+      "darwin-x64": {
+        "env": {
+          "VSCETARGET": "darwin-x64"
+        }
+      },
       "win32-x64": {
         "env": {
           "VSCETARGET": "win32-x64"


### PR DESCRIPTION
Add the macOS Intel target platform 

Fixes https://github.com/open-vsx/publish-extensions/issues/776