### PR TITLE
Add pustelto.bracketeer

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1207,6 +1207,9 @@
   "pucelle.vscode-css-navigation": {
     "repository": "https://github.com/pucelle/vscode-css-navigation"
   },
+  "pustelto.bracketeer": {
+    "repository": "https://github.com/Pustelto/Bracketeer"
+  },
   "rafaelmaiolla.diff": {
     "repository": "https://github.com/rafaelmaiolla/diff-vscode"
   },


### PR DESCRIPTION
Add "pustelto.bracketeer" to extensions.json

<!--

### For community contributors

For the sake of efficiency and simplicity, the easiest way to publish an extension is by having it published by its maintainers, for more info about this please refer to the [README](https://github.com/open-vsx/publish-extensions#when-to-add-an-extension). If the authors are open to publish the extension to Open VSX, you can help them by contributing a GitHub Action using our handy-dandy [direct publish setup](docs/direct_publish_setup.md) doc.

 - If the extension is unmaintained, please create an issue for it instead.

For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

-->

-   [x] I have read the note above about PRs contributing or fixing extensions
-   [x] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).
    - https://github.com/Pustelto/Bracketeer/issues/63
-   [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)
    - MIT

## Description

<!-- Please do not leave this blank -->

This PR adds the [Bracketeer](https://github.com/Pustelto/Bracketeer) extension by [Pustelto](https://github.com/Pustelto).