### PR TITLE
Add ninoseki/mogami to extensions.json

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1127,6 +1127,9 @@
   "Nightrains.robloxlsp": {
     "repository": "https://github.com/NightrainsRbx/RobloxLsp"
   },
+  "ninoseki.mogami": {
+    "repository": "https://github.com/ninoseki/vscode-mogami"
+  },
   "njpwerner.autodocstring": {
     "repository": "https://github.com/NilsJPWerner/autoDocstring"
   },


### PR DESCRIPTION
This PR adds an entry in `extensions.json` for Mogami by @ninoseki 