### PR TITLE
Fixes JSON syntax errors in extension-control/extensions.json

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -514,7 +514,7 @@
                 "id": "sqlfluff.vscode-sqlfluff",
                 "displayName": "sqlfluff"
             }
-        },    
+        },
         "RobertOstermann.vscode-sqlfluff": {
             "disallowInstall": true,
             "extension": {


### PR DESCRIPTION
This is causing the local dev environment to break.

In the meantime you can apply this change to get it to work again:
```
diff --git a/server/src/main/java/org/eclipse/openvsx/extension_control/ExtensionControlService.java b/server/src/main/java/org/eclipse/openvsx/extension_control/ExtensionControlService.java
index 996cf78b..d5fc97ce 100644
--- a/server/src/main/java/org/eclipse/openvsx/extension_control/ExtensionControlService.java
+++ b/server/src/main/java/org/eclipse/openvsx/extension_control/ExtensionControlService.java
@@ -124,7 +124,7 @@ public class ExtensionControlService {
     }

     public JsonNode getExtensionControlJson() throws IOException {
-        var url = new URL("https://github.com/open-vsx/publish-extensions/raw/master/extension-control/extensions.json");
+        var url = new URL("https://raw.githubusercontent.com/davidgomes/publish-extensions/refs/heads/patch-2/extension-control/extensions.json");
         return new ObjectMapper().readValue(url, JsonNode.class);
     }
```