### PR TITLE
depreciate LFS

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -523,11 +523,7 @@
             }
         },
         "ForceConfigControl.lightningflowscanner": {
-            "disallowInstall": true,
-            "extension": {
-                "id": "ForceConfigControl.lightningflowscanner",
-                "displayName": "Lightning Flow Scanner"
-            }
+            "disallowInstall": true
         },
         "DrMerfy.overtype": true,
         "jroesch.lean": true,


### PR DESCRIPTION
This PR adds ForceConfigControl.lightningflowscanner as a deprecated extension in the extension JSON, ensuring disallowing future installs from the Open VSX registry.