### PR TITLE
feat(extensions.json): temporarily restore Boundary.baml-extension-preview

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -443,13 +443,6 @@
                 "displayName": "SerenityOS DSL Syntax Highlight"
             }
         },
-        "Boundary.baml-extension-preview": {
-            "disallowInstall": true,
-            "extension": {
-                "id": "Boundary.baml-extension",
-                "displayName": "BAML"
-            }
-        },
         "lifeart.vscode-ember-unstable": {
             "disallowInstall": true,
             "extension": {


### PR DESCRIPTION
Boundary.baml-extension-preview still comes up in Cursor search results (which are backed by open vsx afaik) presumably because (1) the current name is "Baml (preview2)" and (2) some of the associated tags/categories say "baml"

I'd like to temporarily restore baml-extension-preview so that we can publish a new version free of any metadata, essentially "nuking" it for any users coming to the extension, and then re-deprecate it. Let me know if this sounds reasonable (I recognize that Eclipse doesn't have any control over how Cursor interfaces with the openvsx registry).

cc @filiptronicek as reviewer on #810
