### PR TITLE
Update extensions.json

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -62,6 +62,13 @@
         }
     ],
     "deprecated": {
+        "AnuragKochar.that-typescript-extension" : {
+            "disallowInstall": true,
+            "extension": {
+                "id": "AnuragKochar.that-typescript-extension",
+                "displayName": "that-typescript-extension"
+            }
+        },
          "HerrInformatiker.ai-rules-sync" : {
             "disallowInstall": true,
             "extension": {


### PR DESCRIPTION
This PR deprecates my old extension [that-typescript-extension](https://open-vsx.org/extension/AnuragKochar/that-typescript-extension).

I have renamed the extension, updated the icon, and published the new version under [better-not-any](https://open-vsx.org/extension/AnuragKochar/better-not-any), which should be used going forward.

The old extension should be marked as deprecated and point to the new one as its replacement.