### PR TITLE
deprecate sensmetry.sysml-2ls

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -575,7 +575,14 @@
         "MS-CEINTL.vscode-language-pack-id": true,
         "MS-CEINTL.vscode-language-pack-nl": true,
         "MS-CEINTL.vscode-language-pack-uk": true,
-        "interactive-mcp.interactive-mcp": true
+        "interactive-mcp.interactive-mcp": true,
+        "sensmetry.sysml-2ls": {
+            "disallowInstall": false,
+            "extension": {
+                "id": "sensmetry.syside-editor",
+                "displayName": "Syside Editor"
+            }
+        }
     },
     "migrateToPreRelease": {
         "julialang.language-julia-insider": {


### PR DESCRIPTION
This PR adds [`sensmetry.sysml-2ls`](https://open-vsx.org/extension/sensmetry/sysml-2ls) as a deprecated extension in the extension JSON in favor of [`sensmetry.syside-editor`](https://open-vsx.org/extension/sensmetry/syside-editor).

Both extensions are developed and maintained by Sensmetry, and I am the owner of the namespace in Open-VSX.