### PR TITLE
Deprecate acunniffe.cursor-git-ai

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -596,6 +596,13 @@
                 "id": "sensmetry.syside-editor",
                 "displayName": "Syside Editor"
             }
+        },
+        "acunniffe.cursor-git-ai": {
+            "disallowInstall": true,
+            "extension": {
+                "id": "cursorGitAi",
+                "displayName": "git-ai for Cursor"
+            }
         }
     },
     "migrateToPreRelease": {


### PR DESCRIPTION
## Description

Deprecating https://open-vsx.org/extension/acunniffe/cursor-git-ai because Cursor team released better approach (hooks) in their 1.7