### PR TITLE
Add les-profs-d-info.algorithme-tn to auto-publish list

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -585,6 +585,9 @@
   "laradump.laradump": {
     "repository": "https://github.com/TheJenos/laradump-vscode"
   },
+  "les-profs-d-info.algorithme-tn": {
+    "repository": "https://github.com/romoez/algo-tn-vscode"
+  },
   "lextudio.restructuredtext": {
     "repository": "https://github.com/vscode-restructuredtext/vscode-restructuredtext"
   },


### PR DESCRIPTION
This PR adds the **Algorithme.tn** extension to the Open VSX Registry's auto-publish list.

I am the original extension author, and I have previously signed the **Eclipse Committer Agreement (ECA)**.

The extension ID used in the 'extensions.json' file is the complete identifier from the Visual Studio Marketplace.

Extension Details
- **Extension ID**: les-profs-d-info.algorithme-tn
- **Repository**: https://github.com/romoez/algo-tn-vscode
- **VS Code Marketplace**: https://marketplace.visualstudio.com/items?itemName=les-profs-d-info.algorithme-tn
- **Open VSX Registry**: https://open-vsx.org/extension/les-profs-d-info/algorithme-tn