### PR TITLE
Auto-publish: ForceConfigControl.lightning-flow-scanner-vsx

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -349,6 +349,9 @@
   "folke.vscode-monorepo-workspace": {
     "repository": "https://github.com/folke/vscode-monorepo-workspace"
   },
+  "ForceConfigControl.lightning-flow-scanner-vsx": {
+    "repository": "https://github.com/Flow-Scanner/lightning-flow-scanner-vsx"
+  },
   "formulahendry.auto-close-tag": {
     "repository": "https://github.com/formulahendry/vscode-auto-close-tag"
   },


### PR DESCRIPTION
- [x] I have read the note above about PRs contributing or fixing extensions
- [x] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).
- [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses).

## Description

**Request**:  Add to auto-publish list for mirroring from VS Code Marketplace:

This change configures the workflow to automatically publish the `lightning-flow-scanner-vsx` extension to the Open VSX Marketplace. The goal is to reduce maintenance overhead. 
The JSON validates against extensions-schema.json, and no other files were modified.
I am also registered author of `ForceConfigControl.lightning-flow-scanner-vsx`.

- **Extension**: Lightning Flow Scanner VSX
- **Marketplace**: [marketplace.visualstudio.com/items?itemName=ForceConfigControl.lightning-flow-scanner-vsx](https://marketplace.visualstudio.com/items?itemName=ForceConfigControl.lightning-flow-scanner-vsx)
- **Repository**: [github.com/Flow-Scanner/lightning-flow-scanner-vsx](https://github.com/Flow-Scanner/lightning-flow-scanner-vsx)