### PR TITLE
Add esbuild problem matchers to auto-publish

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -189,6 +189,9 @@
   "CoenraadS.bracket-pair-colorizer": {
     "repository": "https://github.com/CoenraadS/BracketPair"
   },
+  "connor4312.esbuild-problem-matchers": {
+    "repository": "https://github.com/connor4312/esbuild-problem-matchers"
+  },
   "connorshea.vscode-ruby-test-adapter": {
     "repository": "https://github.com/connorshea/vscode-ruby-test-adapter"
   },


### PR DESCRIPTION
-   [x] I have read the note above about PRs contributing or fixing extensions
-   [ ] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).
-   [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description

While I have not reached out myself, I found this: https://github.com/connor4312/esbuild-problem-matchers/issues/6#issuecomment-3097168542

Now... it's obviously quite possible that the author simply didn't want to invest the time. And the project _is_ MIT-licensed. I don't know how you want to handle this (I would be open to publishing a fork) but for extension developers, it sure would be nice to have this.