### PR TITLE
Add repository for comments-cleaner extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -245,6 +245,9 @@
   "DigitalBrainstem.javascript-ejs-support": {
     "repository": "https://github.com/Digitalbrainstem/ejs-grammar"
   },
+  "dionip.comments-cleaner":{
+    "repository": "https://github.com/DioniPinho/Comments-Cleaner"
+  },
   "donjayamanne.git-extension-pack": {
     "repository": "https://github.com/DonJayamanne/git-extension-pack"
   },


### PR DESCRIPTION
- [x] I have read the note above about PRs contributing or fixing extensions
- [x] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).
- [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description

This PR adds the **Comments Cleaner** extension to the auto-publish list.

**Extension Details:**
- **ID:** `Dionip.comments-cleaner`
- **Repository:** https://github.com/DioniPinho/Comments-Cleaner
- **Description:** Remove all comments from code files without modifying the actual code
- **Version:** 1.0.2

I am the author of this extension and would like it to be auto-published to Open VSX.