### PR TITLE
adds support for context-engine

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -197,6 +197,9 @@
   "connorshea.vscode-ruby-test-adapter": {
     "repository": "https://github.com/connorshea/vscode-ruby-test-adapter"
   },
+  "context-engine.context-engine-uploader": {
+    "repository": "https://github.com/m1rl0k/Context-Engine"
+  },
   "csstools.postcss": {
     "repository": "https://github.com/csstools/postcss-language"
   },


### PR DESCRIPTION
This PR adds [context-engine](https://github.com/m1rl0k/Context-Engine) to OpenVSX because several VS Code forks depend on OpenVSX instead of the Visual Studio market place, such as [Kiro.dev](https://kiro.dev/docs/guides/migrating-from-vscode/#extension-compatibility).

Note:
- I am not the author of this plugin
- The license is MIT
