### PR TITLE
deprecate phpcs in favor of vscode-phpcs

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -736,7 +736,8 @@
             "extension": {
                 "id": "johnrdorazio.vscode-phpcs",
                 "displayName": "vscode-phpcs"
-            }
+            },
+            "additionalInfo": "The name change was required on the VS Code marketplace, to avoid a name conflict with the previously published phpcs extensions."
         }
     },
     "migrateToPreRelease": {


### PR DESCRIPTION
## Description

This PR deprecates all previously published `phpcs` extensions in favor of the newly published extension `vscode-phpcs`, seeing that the previously published extensions are currently unmaintained. The name change from `phpcs` to `vscode-phpcs` was required for the VSCode Marketplace, where it was not possible to publish under the same name (perhaps because the previously published extensions were not marked as deprecated).
