### PR TITLE
Add rip-lang.rip and rip-lang.print extensions

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1214,6 +1214,14 @@
   "rioj7.html-related-links": {
     "repository": "https://github.com/rioj7/html-related-links"
   },
+  "rip-lang.print": {
+    "repository": "https://github.com/shreeve/rip-lang",
+    "location": "packages/print/vscode"
+  },
+  "rip-lang.rip": {
+    "repository": "https://github.com/shreeve/rip-lang",
+    "location": "packages/vscode"
+  },
   "ritwickdey.LiveServer": {
     "repository": "https://github.com/ritwickdey/vscode-live-server"
   },


### PR DESCRIPTION
## Summary

This adds two MIT-licensed extensions published under the `rip-lang` publisher on the VS Code Marketplace:

- **rip-lang.rip** — Rip language support (syntax highlighting, types, and editor integration)
- **rip-lang.print** — Syntax-highlighted source code printing with themes and line numbers

Both extensions live in subdirectories of the same repository:
- `rip-lang.rip` → `packages/vscode`
- `rip-lang.print` → `packages/print/vscode`

**Repository:** https://github.com/shreeve/rip-lang
**License:** MIT
**VS Code Marketplace:**
- https://marketplace.visualstudio.com/items?itemName=rip-lang.rip
- https://marketplace.visualstudio.com/items?itemName=rip-lang.print

I am the extension author requesting auto-publishing to OpenVSX.