### PR TITLE
Added Quadlet-LSP extension to autopublish list

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1130,6 +1130,9 @@
   "onecentlin.laravel5-snippets": {
     "repository": "https://github.com/onecentlin/laravel5-snippets-vscode"
   },
+  "onlyati.quadlet-lsp": {
+    "repository": "https://github.com/onlyati/quadlet-lsp-vscode-extension"
+  },
   "openfl.lime-vscode-extension": {
     "repository": "https://github.com/openfl/lime-vscode-extension"
   },


### PR DESCRIPTION
-   [x] I have read the note above about PRs contributing or fixing extensions
-   [x] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX [here](https://github.com/onlyati/quadlet-lsp/issues/193).
-   [X] This extension is MIT licensed

## Description

This PR adds onlyati.quadlet-lsp to the list of extensions to be published automatically.

I talked with the author who is happy to have it published but unavailable to do it themselves.

Since the extension relies on binary blobs being downloaded, I question whether it's going to work. I remain available to fix this upon further guidance, I just don't fully understand the CI action, so I am not sure how to adjust my contribution to properly work