### PR TITLE
Add restore-terminals extension to extensions.json

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -299,6 +299,10 @@
     "repository": "https://github.com/erlang-ls/vscode",
     "prepublish": "npm run compile"
   },
+  "EthanSK.restore-terminals": {
+    "repository": "https://github.com/EthanSK/restore-terminals-vscode",
+    "prepublish": "npm run compile"
+  },
   "ethan-reesor.vscode-go-test-adapter": {
     "repository": "https://gitlab.com/firelizzard/vscode-go-test-adapter",
     "prepublish": "sed -ri \"s_]\\(img/_](https://gitlab.com/firelizzard/vscode-go-test-adapter/-/raw/master/img/_g\" README.md"


### PR DESCRIPTION
-   [x] I have read the note above about PRs contributing or fixing extensions
-   [x] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).
-   [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description

I have not reached out but someone else has, 5 years ago: https://github.com/EthanSK/restore-terminals-vscode/issues/21

As for what it does, please see: https://marketplace.visualstudio.com/items?itemName=EthanSK.restore-terminals