### PR TITLE
Auto-publish `vscode-glualint`

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -3,6 +3,9 @@
   "13xforever.language-x86-64-assembly": {
     "repository": "https://github.com/13xforever/x86_64-assembly-vscode"
   },
+  "Goz3rr.vscode-glualint": {
+    "repository": "https://github.com/Goz3rr/vscode-glualint/tree/master"
+  },
   "aaron-bond.better-comments": {
     "repository": "https://github.com/aaron-bond/better-comments"
   },


### PR DESCRIPTION
-   [x] I have read the note above about PRs contributing or fixing extensions
-   [x] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).
-   [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description

This PR adds the [vscode-glualint](https://github.com/Goz3rr/vscode-glualint) extension to the auto-publish list.
Someone has already reached out to the author of the extension asking for the extension to be released on Open VSX. (They have not responded for 3 years)
Using auto-publish is probably the reasonable thing to do here as the author may be inactive and the extension is unmaintained due to a issue already being opened on the repository.