### PR TITLE
add TinyGo extension (tinygo.vscode-tinygo)

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1345,6 +1345,9 @@
   "tecosaur.latex-utilities": {
     "repository": "https://github.com/tecosaur/LaTeX-Utilities"
   },
+  "tinygo.vscode-tinygo": {
+    "repository": "https://github.com/tinygo-org/vscode-tinygo"
+  },
   "Tobiah.unity-tools": {
     "repository": "https://github.com/TobiahZ/unity-tools"
   },


### PR DESCRIPTION
-   [x] I have read the note above about PRs contributing or fixing extensions
-   [x] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).
-   [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description

This PR adds the TinyGo (tinygo.vscode-tinygo, https://github.com/tinygo-org/vscode-tinygo) extension licensed under the BSD-3-Clause license into the extensions.json file.

There's an open issue in https://github.com/tinygo-org/vscode-tinygo/issues/12 since October 2024 requesting the developers to publish the extension to Open VSX, so far no reply from the developers has been received.