### PR TITLE
Deprecate MATLAB Open VSX fork

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -892,6 +892,14 @@
                 "displayName": "Live Preview"
             }
         },
+        "chrisatcursor.language-matlab": {
+            "disallowInstall": false,
+            "extension": {
+                "id": "mathworks.language-matlab",
+                "displayName": "MATLAB"
+            },
+            "additionalInfo": "MathWorks now publishes and maintains the official MATLAB extension on Open VSX. Please migrate to mathworks.language-matlab."
+        },
         "Shan.code-settings-sync": {
             "disallowInstall": true,
             "additionalInfo": "Please use the built-in [Settings Sync](https://aka.ms/vscode-settings-sync-help) functionality instead."


### PR DESCRIPTION
## Summary
- Mark `chrisatcursor.language-matlab` as deprecated in favor of `mathworks.language-matlab`.
- Keep `disallowInstall` set to `false` so existing users and downloads are not cut off while users migrate.

## Test plan
- `python3 -m json.tool extension-control/extensions.json >/dev/null`

Made with [Cursor](https://cursor.com)