### PR TITLE
Deprecate redhat.devspaces-copilot-chat-integration.

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -1485,6 +1485,14 @@
 		},
 		"IBM.vscode-sourceorbit": {
             "disallowInstall": false
+        },
+        "redhat.devspaces-copilot-chat-integration": {
+            "disallowInstall": true,
+            "extension": {
+                "id": "redhat.devspaces-copilot-chat-integration",
+                "displayName": "Dev Spaces Copilot Chat Integration"
+            },
+            "additionalInfo": "This extension has been integrated into VS Code as of version 1.116.0."
         }
     },
     "migrateToPreRelease": {


### PR DESCRIPTION
This extension was added from https://github.com/EclipseFdn/publish-extensions/issues/1101 . As mentioned in https://github.com/EclipseFdn/open-vsx.org/issues/10656#issuecomment-4548053304 , this extension is now part of VS Code 1.116.0. As a result I would like to deprecate it.

I have already  deprecated the [repository](https://github.com/redhat-developer/devspaces-copilot-chat-integration/blob/main/package.json) that publishes it to OpenVSX.