### PR TITLE
Deprecate CicerBro.phpantom → phpantom.phpantom

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -950,6 +950,14 @@
             },
             "additionalInfo": "MathWorks now publishes and maintains the official MATLAB extension on Open VSX. Please migrate to mathworks.language-matlab."
         },
+        "CicerBro.phpantom": {
+            "disallowInstall": true,
+            "extension": {
+                "id": "phpantom.phpantom",
+                "displayName": "PHPantom"
+            },
+            "additionalInfo": "This community listing is deprecated. Install the official phpantom.phpantom extension instead."
+        },
         "Shan.code-settings-sync": {
             "disallowInstall": true,
             "additionalInfo": "Please use the built-in [Settings Sync](https://aka.ms/vscode-settings-sync-help) functionality instead."


### PR DESCRIPTION
## Summary
- Mark `CicerBro.phpantom` as deprecated on Open VSX
- Set `disallowInstall: true` so new installs are blocked
- Recommend replacement `phpantom.phpantom` (official PHPantom extension)

I am the publisher of `CicerBro.phpantom`. Version 0.3.3 is already published with an in-editor migration prompt; this control-file entry makes the deprecation official in the Open VSX UI (applied by the nightly batch job after merge).