### PR TITLE
Deprecate Singularis.singularis publisher placeholder

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -1070,6 +1070,14 @@
             "disallowInstall": true,
             "additionalInfo": "Please use the built-in [Settings Sync](https://aka.ms/vscode-settings-sync-help) functionality instead."
         },
+        "Singularis.singularis": {
+            "disallowInstall": true,
+            "extension": {
+                "id": "boobuh.cursor-apollo-sandbox",
+                "displayName": "Cursor Apollo Sandbox"
+            },
+            "additionalInfo": "Publisher namespace placeholder — not a functional extension. Install boobuh.cursor-apollo-sandbox (Cursor Apollo Sandbox) instead."
+        },
         "tiehuis.zig": {
             "disallowInstall": true,
             "extension": {


### PR DESCRIPTION
## Summary

- Deprecates `Singularis.singularis`, a publisher namespace bootstrap that was accidentally published alongside the real extension.
- Blocks new installs (`disallowInstall: true`).
- Points users to **`boobuh.cursor-apollo-sandbox`** (Cursor Apollo Sandbox).

## Context

Publisher: Boobuh (`Singularis` namespace on Open VSX). The placeholder shared branding with Apollo Sandbox and appeared as a duplicate in Cursor marketplace search.

Final deprecated stub published as `Singularis.singularis` v0.0.4.

## Test plan

- [ ] Nightly extension-control job marks listing deprecated
- [ ] Cursor marketplace search for `boobuh` no longer suggests installing `Singularis.singularis`

Made with [Cursor](https://cursor.com)