### PR TITLE
Deprecate gabrielbacha.vscode-focus-mode

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -967,6 +967,14 @@
         }
     ],
     "deprecated": {
+        "gabrielbacha.vscode-focus-mode": {
+            "disallowInstall": true,
+            "extension": {
+                "id": "gabrielbacha.explorer-focus-presets",
+                "displayName": "Explorer Focus Presets"
+            },
+            "additionalInfo": "This extension was renamed to keep a consistent extension identity across Open VSX and the Visual Studio Marketplace."
+        },
         "dschibster.sf-org-list" : {
             "disallowInstall": true,
             "extension": {


### PR DESCRIPTION
The extension has been renamed to gabrielbacha.explorer-focus-presets so it can use one consistent identity across Open VSX and the Visual Studio Marketplace. This marks the old Open VSX identity as deprecated, disallows new installs, and directs users to the replacement.