### PR TITLE
Add lch.nginx-beautifier

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -552,6 +552,9 @@
   "laradump.laradump": {
     "repository": "https://github.com/TheJenos/laradump-vscode"
   },
+  "lch.nginx-beautifier": {
+    "repository": "https://github.com/LCH-1/nginx-beautifier"
+  },
   "lextudio.restructuredtext": {
     "repository": "https://github.com/vscode-restructuredtext/vscode-restructuredtext"
   },


### PR DESCRIPTION
- [x] I have read the note above about PRs contributing or fixing extensions
- [x] I am the extension maintainer and attempted direct Open VSX publishing first
- [x] This extension uses the OSI-approved MIT license

## Description

Adds `lch.nginx-beautifier` to the Open VSX auto-publish list.

The extension is maintained at https://github.com/LCH-1/nginx-beautifier and version 0.2.1 is already published on the Visual Studio Marketplace. Direct Open VSX publishing was attempted, but the maintainer account currently receives a 403 when generating a new access token and has no visible access to the existing `lch` namespace. Auto-publishing will make the extension available to Cursor users while preserving the Marketplace release as the source.