### PR TITLE
Build ms-python tool extensions with Python 3.10

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -754,6 +754,7 @@
   },
   "ms-python.autopep8": {
     "repository": "https://github.com/microsoft/vscode-autopep8",
+    "pythonVersion": "3.10",
     "custom": [
       "python -m pip install -U pip",
       "python -m pip install wheel",
@@ -766,6 +767,7 @@
   },
   "ms-python.black-formatter": {
     "repository": "https://github.com/microsoft/vscode-black-formatter",
+    "pythonVersion": "3.10",
     "custom": [
       "python -m pip install -U pip",
       "python -m pip install wheel",
@@ -819,6 +821,7 @@
   },
   "ms-python.flake8": {
     "repository": "https://github.com/microsoft/vscode-flake8",
+    "pythonVersion": "3.10",
     "custom": [
       "python -m pip install -U pip",
       "python -m pip install wheel",
@@ -855,6 +858,7 @@
   },
   "ms-python.pylint": {
     "repository": "https://github.com/microsoft/vscode-pylint",
+    "pythonVersion": "3.10",
     "custom": [
       "python -m pip install -U pip",
       "python -m pip install wheel",


### PR DESCRIPTION
<!--

### For extension authors

`publish-extensions` exists to seed the Open VSX marketplace, and also serves as a place for extensions that cannot feasibly be published directly by the extensions authors. In the long-run it is better for extension owners to publish their own plugins because:

1. Any future issues (features/bugs) with any published extensions in Open VSX will be directed to their original repo/source-control, and not confused with this repo publish-extensions.
2. Extensions published by official authors are shown within the Open VSX marketplace as such. Whereas extensions published via publish-extensions display a warning that the publisher (this repository) is not the official author.
3. Extension owners who publish their own extensions get greater flexibility on the publishing/release process, therefore ensure more accuracy/stability. For instance, in some cases publish-extensions has build steps within this repository, which can cause some uploaded plugin versions to break (e.g. if a plugin build step changes).

If you are the author of the extension being raised in this PR, please first consider directly publishing the extension yourself. You can refer to our [direct publish setup](docs/direct_publish_setup.md) doc for a guide on how to publish your plugin to Open VSX.

### For community contributors

For the sake of efficiency and simplicity, the easiest way to publish an extension is by having it published by its maintainers, for more info about this please refer to the [README](https://github.com/open-vsx/publish-extensions#when-to-add-an-extension). If the authors are open to publish the extension to Open VSX, you can help them by contributing a GitHub Action using our handy-dandy [direct publish setup](docs/direct_publish_setup.md) doc.

 - If the extension is unmaintained, please create an issue for it instead.

For Work In Progress Pull Requests, please use the Draft PR feature,
see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

-->

-   [x] I have read the note above about PRs contributing or fixing extensions
-   [ ] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).
-   [x] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description

The nox `install_bundled_libs` session in microsoft/vscode-{pylint,black-formatter,flake8,autopep8} is declared as `@nox.session(python="3.10")`, so the build fails on the default 3.9 interpreter and these extensions can no longer be published.

pylint additionally moved to pygls 2.x, which requires Python >= 3.10, in microsoft/vscode-pylint#645 / #643 (Feb 2026). As a result Open VSX is stuck on 2025.2.0 while upstream stable is 2026.6.0, and the published build crashes with `AttributeError: module 'pygls.server' has no attribute 'LanguageServer'` when `pylint.importStrategy` is set to `fromEnvironment`.

Set `pythonVersion` to 3.10 for the four nox-based ms-python tool extensions so `pyenv global` selects an interpreter the pinned session can use.

Refs #838
