### PR TITLE
Deprecate afedb.cooked

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -1647,6 +1647,10 @@
                 "displayName": "Dev Spaces Copilot Chat Integration"
             },
             "additionalInfo": "This extension has been integrated into VS Code as of version 1.116.0."
+        },
+        "afedb.cooked": {
+            "disallowInstall": true,
+            "additionalInfo": "This extension is no longer maintained."
         }
     },
     "migrateToPreRelease": {


### PR DESCRIPTION
The publisher no longer maintains or distributes this extension. Mark it as deprecated and disallow new installations.