### PR TITLE
Deprecate V1 of the MOSAICO Reference Client, pointing users to V2

### DIFF
--- a/extension-control/extensions.json
+++ b/extension-control/extensions.json
@@ -1649,6 +1649,14 @@
         "afedb.cooked": {
             "disallowInstall": true,
             "additionalInfo": "This extension is no longer maintained."
+        },
+        "MOSAICO.mosaico-reference-client": {
+            "disallowInstall": false,
+            "extension": {
+                "id": "MOSAICO.mosaico-reference-client-v2",
+                "displayName": "MOSAICO Reference Client V2"
+            },
+            "additionalInfo": "Development has moved on to version 2, which is re-built from the ground up focusing on the MOSAICO requirements."
         }
     },
     "migrateToPreRelease": {


### PR DESCRIPTION
-   [X] I have read the note above about PRs contributing or fixing extensions
-   [X] I have tried reaching out to the extension maintainers about publishing this extension to Open VSX (if not, please create an issue in the extension's repo using [this template](https://github.com/open-vsx/publish-extensions/blob/HEAD/docs/external_contribution_request.md)).
-   [X] This extension has an [OSI-approved OSS license](https://opensource.org/licenses) (we don't accept proprietary extensions in this repository)

## Description

Within the MOSAICO European research project, we have implemented a VS Code extension that acts as the reference client to our agent communities. Our first version was published to OpenVSX here:

https://open-vsx.org/extension/MOSAICO/mosaico-reference-client

The above first version was a fork of [Continue](https://github.com/continuedev/continue/), which is no longer actively maintained. We have developed a Version 2 client from scratch, that focuses on what we need for MOSAICO itself:

https://open-vsx.org/extension/MOSAICO/mosaico-reference-client-v2

We would like to deprecate the V1 client, and point users to the V2 client.